### PR TITLE
A number of small QOL changes related to lfs_util.h

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "lfs.h"
-#include "lfs_util.h"
 
 
 /// Caching block device operations ///

--- a/lfs.h
+++ b/lfs.h
@@ -7,8 +7,7 @@
 #ifndef LFS_H
 #define LFS_H
 
-#include <stdint.h>
-#include <stdbool.h>
+#include "lfs_util.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -66,25 +65,6 @@ typedef uint32_t lfs_block_t;
 #define LFS_ATTR_MAX 1022
 #endif
 
-// Possible error codes, these are negative to allow
-// valid positive return values
-enum lfs_error {
-    LFS_ERR_OK          = 0,    // No error
-    LFS_ERR_IO          = -5,   // Error during device operation
-    LFS_ERR_CORRUPT     = -84,  // Corrupted
-    LFS_ERR_NOENT       = -2,   // No directory entry
-    LFS_ERR_EXIST       = -17,  // Entry already exists
-    LFS_ERR_NOTDIR      = -20,  // Entry is not a dir
-    LFS_ERR_ISDIR       = -21,  // Entry is a dir
-    LFS_ERR_NOTEMPTY    = -39,  // Dir is not empty
-    LFS_ERR_BADF        = -9,   // Bad file number
-    LFS_ERR_FBIG        = -27,  // File too large
-    LFS_ERR_INVAL       = -22,  // Invalid parameter
-    LFS_ERR_NOSPC       = -28,  // No space left on device
-    LFS_ERR_NOMEM       = -12,  // No more memory available
-    LFS_ERR_NOATTR      = -61,  // No data/attr available
-    LFS_ERR_NAMETOOLONG = -36,  // File name too long
-};
 
 // File types
 enum lfs_type {

--- a/lfs_util.c
+++ b/lfs_util.c
@@ -7,7 +7,7 @@
 #include "lfs_util.h"
 
 // Only compile if user does not provide custom config
-#ifndef LFS_CONFIG
+#ifndef LFS_UTIL
 
 
 // Software CRC implementation with small lookup table

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -3,20 +3,21 @@
  *
  * Copyright (c) 2017, Arm Limited. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Can be overridden by users with their own configuration by defining
+ * LFS_UTIL as a header file (-DLFS_UTIL=my_lfs_util.h)
+ *
+ * If LFS_UTIL is defined, none of the default definitions will be
+ * emitted and must be provided by the user's header file. To start, I would
+ * suggest copying lfs_util.h and modifying as needed.
  */
 #ifndef LFS_UTIL_H
 #define LFS_UTIL_H
 
-// Users can override lfs_util.h with their own configuration by defining
-// LFS_CONFIG as a header file to include (-DLFS_CONFIG=lfs_config.h).
-//
-// If LFS_CONFIG is used, none of the default utils will be emitted and must be
-// provided by the config file. To start, I would suggest copying lfs_util.h
-// and modifying as needed.
-#ifdef LFS_CONFIG
+#ifdef LFS_UTIL
 #define LFS_STRINGIZE(x) LFS_STRINGIZE2(x)
 #define LFS_STRINGIZE2(x) #x
-#include LFS_STRINGIZE(LFS_CONFIG)
+#include LFS_STRINGIZE(LFS_UTIL)
 #else
 
 // System includes
@@ -42,6 +43,28 @@
 extern "C"
 {
 #endif
+
+
+// Possible error codes, these are negative to allow valid positive
+// return values. May be redefined to system error codes as long as
+// they are negative.
+enum lfs_error {
+    LFS_ERR_OK          = 0,    // No error
+    LFS_ERR_IO          = -5,   // Error during device operation
+    LFS_ERR_CORRUPT     = -84,  // Corrupted
+    LFS_ERR_NOENT       = -2,   // No directory entry
+    LFS_ERR_EXIST       = -17,  // Entry already exists
+    LFS_ERR_NOTDIR      = -20,  // Entry is not a dir
+    LFS_ERR_ISDIR       = -21,  // Entry is a dir
+    LFS_ERR_NOTEMPTY    = -39,  // Dir is not empty
+    LFS_ERR_BADF        = -9,   // Bad file number
+    LFS_ERR_FBIG        = -27,  // File too large
+    LFS_ERR_INVAL       = -22,  // Invalid parameter
+    LFS_ERR_NOSPC       = -28,  // No space left on device
+    LFS_ERR_NOMEM       = -12,  // No more memory available
+    LFS_ERR_NOATTR      = -61,  // No data/attr available
+    LFS_ERR_NAMETOOLONG = -36,  // File name too long
+};
 
 
 // Macros, may be replaced by system specific wrappers. Arguments to these
@@ -146,8 +169,8 @@ static inline uint32_t lfs_popc(uint32_t a) {
 
 // Find the sequence comparison of a and b, this is the distance
 // between a and b ignoring overflow
-static inline int lfs_scmp(uint32_t a, uint32_t b) {
-    return (int)(unsigned)(a - b);
+static inline int32_t lfs_scmp(uint32_t a, uint32_t b) {
+    return (int32_t)(uint32_t)(a - b);
 }
 
 // Convert between 32-bit little-endian and native order


### PR DESCRIPTION
- Removed stdlib includes from lfs.h, these should all go through lfs_util.h to let users override these definitions if stdlib is unavailable on their system.

- Changed the name of the LFS_CONFIG macro to LFS_UTIL to avoid confusion with the lfs_config struct. This also hints that LFS_UTIL is related to lfs_util.h.

  LFS_UTIL allows the user to override lfs_util.h so they can provide their own system-level dependencies such as malloc, tracing, builtins, stdint definitions, string.h, and others.

- Moved error code definitions to lfs_util.h. This lets users override the error codes to replace them with their own error codes and avoid a translation layer in some situations. Note the error codes must still be in the range of a negative int.

Note that this is very likely to cause build issues for anyone currently using LFS_CONFIG.

To fix:
- Change LFS_CONFIG to LFS_UTIL
- Make sure you have a copy of the error code definitions in your customized lfs_util.h

Because of these changes this PR will need to wait for at least a minor release.