### PR TITLE
Fix assert

### DIFF
--- a/bd/lfs_testbd.c
+++ b/bd/lfs_testbd.c
@@ -207,7 +207,7 @@ int lfs_testbd_prog(const struct lfs_config *cfg, lfs_block_t block,
         bd->power_cycles -= 1;
         if (bd->power_cycles == 0) {
             // sync to make sure we persist the last changes
-            assert(lfs_testbd_rawsync(cfg) == 0);
+            LFS_ASSERT(lfs_testbd_rawsync(cfg) == 0);
             // simulate power loss
             exit(33);
         }
@@ -254,7 +254,7 @@ int lfs_testbd_erase(const struct lfs_config *cfg, lfs_block_t block) {
         bd->power_cycles -= 1;
         if (bd->power_cycles == 0) {
             // sync to make sure we persist the last changes
-            assert(lfs_testbd_rawsync(cfg) == 0);
+            LFS_ASSERT(lfs_testbd_rawsync(cfg) == 0);
             // simulate power loss
             exit(33);
         }


### PR DESCRIPTION
Fix for a minor annoyance where the testbd device uses `assert` rather than `LFS_ASSERT`