### PR TITLE
Add thread safe wrappers

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -1525,7 +1525,7 @@ static int lfs_dir_compact(lfs_t *lfs,
         if (lfs_pair_cmp(dir->pair, (const lfs_block_t[2]){0, 1}) == 0) {
             // oh no! we're writing too much to the superblock,
             // should we expand?
-            lfs_ssize_t res = lfs_fs_size(lfs);
+            lfs_ssize_t res = _lfs_fs_size(lfs);
             if (res < 0) {
                 return res;
             }
@@ -1906,7 +1906,7 @@ compact:
 
 
 /// Top level directory operations ///
-int lfs_mkdir(lfs_t *lfs, const char *path) {
+int _lfs_mkdir(lfs_t *lfs, const char *path) {
     LFS_TRACE("lfs_mkdir(%p, \"%s\")", (void*)lfs, path);
     // deorphan if we haven't yet, needed at most once after poweron
     int err = lfs_fs_forceconsistency(lfs);
@@ -2005,7 +2005,7 @@ int lfs_mkdir(lfs_t *lfs, const char *path) {
     return 0;
 }
 
-int lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
+int _lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
     LFS_TRACE("lfs_dir_open(%p, %p, \"%s\")", (void*)lfs, (void*)dir, path);
     lfs_stag_t tag = lfs_dir_find(lfs, &dir->m, &path, NULL);
     if (tag < 0) {
@@ -2056,7 +2056,7 @@ int lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
     return 0;
 }
 
-int lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir) {
+int _lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir) {
     LFS_TRACE("lfs_dir_close(%p, %p)", (void*)lfs, (void*)dir);
     // remove from list of mdirs
     for (struct lfs_mlist **p = &lfs->mlist; *p; p = &(*p)->next) {
@@ -2070,7 +2070,7 @@ int lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir) {
     return 0;
 }
 
-int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
+int _lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
     LFS_TRACE("lfs_dir_read(%p, %p, %p)",
             (void*)lfs, (void*)dir, (void*)info);
     memset(info, 0, sizeof(*info));
@@ -2123,11 +2123,11 @@ int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
     return true;
 }
 
-int lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
+int _lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
     LFS_TRACE("lfs_dir_seek(%p, %p, %"PRIu32")",
             (void*)lfs, (void*)dir, off);
     // simply walk from head dir
-    int err = lfs_dir_rewind(lfs, dir);
+    int err = _lfs_dir_rewind(lfs, dir);
     if (err) {
         LFS_TRACE("lfs_dir_seek -> %d", err);
         return err;
@@ -2166,14 +2166,14 @@ int lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
     return 0;
 }
 
-lfs_soff_t lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir) {
+lfs_soff_t _lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir) {
     LFS_TRACE("lfs_dir_tell(%p, %p)", (void*)lfs, (void*)dir);
     (void)lfs;
     LFS_TRACE("lfs_dir_tell -> %"PRId32, dir->pos);
     return dir->pos;
 }
 
-int lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir) {
+int _lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir) {
     LFS_TRACE("lfs_dir_rewind(%p, %p)", (void*)lfs, (void*)dir);
     // reload the head dir
     int err = lfs_dir_fetch(lfs, &dir->m, dir->head);
@@ -2380,7 +2380,7 @@ static int lfs_ctz_traverse(lfs_t *lfs,
 
 
 /// Top level file operations ///
-int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
+int _lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags,
         const struct lfs_file_config *cfg) {
     LFS_TRACE("lfs_file_opencfg(%p, %p, \"%s\", %x, %p {"
@@ -2529,26 +2529,26 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
 cleanup:
     // clean up lingering resources
     file->flags |= LFS_F_ERRED;
-    lfs_file_close(lfs, file);
+    _lfs_file_close(lfs, file);
     LFS_TRACE("lfs_file_opencfg -> %d", err);
     return err;
 }
 
-int lfs_file_open(lfs_t *lfs, lfs_file_t *file,
+int _lfs_file_open(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags) {
     LFS_TRACE("lfs_file_open(%p, %p, \"%s\", %x)",
             (void*)lfs, (void*)file, path, flags);
     static const struct lfs_file_config defaults = {0};
-    int err = lfs_file_opencfg(lfs, file, path, flags, &defaults);
+    int err = _lfs_file_opencfg(lfs, file, path, flags, &defaults);
     LFS_TRACE("lfs_file_open -> %d", err);
     return err;
 }
 
-int lfs_file_close(lfs_t *lfs, lfs_file_t *file) {
+int _lfs_file_close(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_close(%p, %p)", (void*)lfs, (void*)file);
     LFS_ASSERT(file->flags & LFS_F_OPENED);
 
-    int err = lfs_file_sync(lfs, file);
+    int err = _lfs_file_sync(lfs, file);
 
     // remove from list of mdirs
     for (struct lfs_mlist **p = &lfs->mlist; *p; p = &(*p)->next) {
@@ -2679,12 +2679,12 @@ static int lfs_file_flush(lfs_t *lfs, lfs_file_t *file) {
                 // copy over a byte at a time, leave it up to caching
                 // to make this efficient
                 uint8_t data;
-                lfs_ssize_t res = lfs_file_read(lfs, &orig, &data, 1);
+                lfs_ssize_t res = _lfs_file_read(lfs, &orig, &data, 1);
                 if (res < 0) {
                     return res;
                 }
 
-                res = lfs_file_write(lfs, file, &data, 1);
+                res = _lfs_file_write(lfs, file, &data, 1);
                 if (res < 0) {
                     return res;
                 }
@@ -2731,7 +2731,7 @@ relocate:
     return 0;
 }
 
-int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
+int _lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_sync(%p, %p)", (void*)lfs, (void*)file);
     LFS_ASSERT(file->flags & LFS_F_OPENED);
 
@@ -2788,7 +2788,7 @@ int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
     return 0;
 }
 
-lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
+lfs_ssize_t _lfs_file_read(lfs_t *lfs, lfs_file_t *file,
         void *buffer, lfs_size_t size) {
     LFS_TRACE("lfs_file_read(%p, %p, %p, %"PRIu32")",
             (void*)lfs, (void*)file, buffer, size);
@@ -2868,7 +2868,7 @@ lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
     return size;
 }
 
-lfs_ssize_t lfs_file_write(lfs_t *lfs, lfs_file_t *file,
+lfs_ssize_t _lfs_file_write(lfs_t *lfs, lfs_file_t *file,
         const void *buffer, lfs_size_t size) {
     LFS_TRACE("lfs_file_write(%p, %p, %p, %"PRIu32")",
             (void*)lfs, (void*)file, buffer, size);
@@ -2903,7 +2903,7 @@ lfs_ssize_t lfs_file_write(lfs_t *lfs, lfs_file_t *file,
         file->pos = file->ctz.size;
 
         while (file->pos < pos) {
-            lfs_ssize_t res = lfs_file_write(lfs, file, &(uint8_t){0}, 1);
+            lfs_ssize_t res = _lfs_file_write(lfs, file, &(uint8_t){0}, 1);
             if (res < 0) {
                 LFS_TRACE("lfs_file_write -> %"PRId32, res);
                 return res;
@@ -2999,7 +2999,7 @@ relocate:
     return size;
 }
 
-lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
+lfs_soff_t _lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
         lfs_soff_t off, int whence) {
     LFS_TRACE("lfs_file_seek(%p, %p, %"PRId32", %d)",
             (void*)lfs, (void*)file, off, whence);
@@ -3034,7 +3034,7 @@ lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
     return npos;
 }
 
-int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
+int _lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     LFS_TRACE("lfs_file_truncate(%p, %p, %"PRIu32")",
             (void*)lfs, (void*)file, size);
     LFS_ASSERT(file->flags & LFS_F_OPENED);
@@ -3046,7 +3046,7 @@ int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     }
 
     lfs_off_t pos = file->pos;
-    lfs_off_t oldsize = lfs_file_size(lfs, file);
+    lfs_off_t oldsize = _lfs_file_size(lfs, file);
     if (size < oldsize) {
         // need to flush since directly changing metadata
         int err = lfs_file_flush(lfs, file);
@@ -3070,7 +3070,7 @@ int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     } else if (size > oldsize) {
         // flush+seek if not already at end
         if (file->pos != oldsize) {
-            lfs_soff_t res = lfs_file_seek(lfs, file, 0, LFS_SEEK_END);
+            lfs_soff_t res = _lfs_file_seek(lfs, file, 0, LFS_SEEK_END);
             if (res < 0) {
                 LFS_TRACE("lfs_file_truncate -> %"PRId32, res);
                 return (int)res;
@@ -3079,7 +3079,7 @@ int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
 
         // fill with zeros
         while (file->pos < size) {
-            lfs_ssize_t res = lfs_file_write(lfs, file, &(uint8_t){0}, 1);
+            lfs_ssize_t res = _lfs_file_write(lfs, file, &(uint8_t){0}, 1);
             if (res < 0) {
                 LFS_TRACE("lfs_file_truncate -> %"PRId32, res);
                 return (int)res;
@@ -3088,7 +3088,7 @@ int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     }
 
     // restore pos
-    lfs_soff_t res = lfs_file_seek(lfs, file, pos, LFS_SEEK_SET);
+    lfs_soff_t res = _lfs_file_seek(lfs, file, pos, LFS_SEEK_SET);
     if (res < 0) {
       LFS_TRACE("lfs_file_truncate -> %"PRId32, res);
       return (int)res;
@@ -3098,7 +3098,7 @@ int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     return 0;
 }
 
-lfs_soff_t lfs_file_tell(lfs_t *lfs, lfs_file_t *file) {
+lfs_soff_t _lfs_file_tell(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_tell(%p, %p)", (void*)lfs, (void*)file);
     LFS_ASSERT(file->flags & LFS_F_OPENED);
     (void)lfs;
@@ -3106,9 +3106,9 @@ lfs_soff_t lfs_file_tell(lfs_t *lfs, lfs_file_t *file) {
     return file->pos;
 }
 
-int lfs_file_rewind(lfs_t *lfs, lfs_file_t *file) {
+int _lfs_file_rewind(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_rewind(%p, %p)", (void*)lfs, (void*)file);
-    lfs_soff_t res = lfs_file_seek(lfs, file, 0, LFS_SEEK_SET);
+    lfs_soff_t res = _lfs_file_seek(lfs, file, 0, LFS_SEEK_SET);
     if (res < 0) {
         LFS_TRACE("lfs_file_rewind -> %"PRId32, res);
         return (int)res;
@@ -3118,7 +3118,7 @@ int lfs_file_rewind(lfs_t *lfs, lfs_file_t *file) {
     return 0;
 }
 
-lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file) {
+lfs_soff_t _lfs_file_size(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_size(%p, %p)", (void*)lfs, (void*)file);
     LFS_ASSERT(file->flags & LFS_F_OPENED);
     (void)lfs;
@@ -3134,7 +3134,7 @@ lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file) {
 
 
 /// General fs operations ///
-int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info) {
+int _lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info) {
     LFS_TRACE("lfs_stat(%p, \"%s\", %p)", (void*)lfs, path, (void*)info);
     lfs_mdir_t cwd;
     lfs_stag_t tag = lfs_dir_find(lfs, &cwd, &path, NULL);
@@ -3148,7 +3148,7 @@ int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info) {
     return err;
 }
 
-int lfs_remove(lfs_t *lfs, const char *path) {
+int _lfs_remove(lfs_t *lfs, const char *path) {
     LFS_TRACE("lfs_remove(%p, \"%s\")", (void*)lfs, path);
     // deorphan if we haven't yet, needed at most once after poweron
     int err = lfs_fs_forceconsistency(lfs);
@@ -3229,7 +3229,7 @@ int lfs_remove(lfs_t *lfs, const char *path) {
     return 0;
 }
 
-int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
+int _lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
     LFS_TRACE("lfs_rename(%p, \"%s\", \"%s\")", (void*)lfs, oldpath, newpath);
 
     // deorphan if we haven't yet, needed at most once after poweron
@@ -3374,7 +3374,7 @@ int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
     return 0;
 }
 
-lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path,
+lfs_ssize_t _lfs_getattr(lfs_t *lfs, const char *path,
         uint8_t type, void *buffer, lfs_size_t size) {
     LFS_TRACE("lfs_getattr(%p, \"%s\", %"PRIu8", %p, %"PRIu32")",
             (void*)lfs, path, type, buffer, size);
@@ -3437,7 +3437,7 @@ static int lfs_commitattr(lfs_t *lfs, const char *path,
             {LFS_MKTAG(LFS_TYPE_USERATTR + type, id, size), buffer}));
 }
 
-int lfs_setattr(lfs_t *lfs, const char *path,
+int _lfs_setattr(lfs_t *lfs, const char *path,
         uint8_t type, const void *buffer, lfs_size_t size) {
     LFS_TRACE("lfs_setattr(%p, \"%s\", %"PRIu8", %p, %"PRIu32")",
             (void*)lfs, path, type, buffer, size);
@@ -3451,7 +3451,7 @@ int lfs_setattr(lfs_t *lfs, const char *path,
     return err;
 }
 
-int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type) {
+int _lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type) {
     LFS_TRACE("lfs_removeattr(%p, \"%s\", %"PRIu8")", (void*)lfs, path, type);
     int err = lfs_commitattr(lfs, path, type, NULL, 0x3ff);
     LFS_TRACE("lfs_removeattr -> %d", err);
@@ -3584,7 +3584,7 @@ static int lfs_deinit(lfs_t *lfs) {
     return 0;
 }
 
-int lfs_format(lfs_t *lfs, const struct lfs_config *cfg) {
+int _lfs_format(lfs_t *lfs, const struct lfs_config *cfg) {
     LFS_TRACE("lfs_format(%p, %p {.context=%p, "
                 ".read=%p, .prog=%p, .erase=%p, .sync=%p, "
                 ".read_size=%"PRIu32", .prog_size=%"PRIu32", "
@@ -3665,7 +3665,7 @@ cleanup:
     return err;
 }
 
-int lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
+int _lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
     LFS_TRACE("lfs_mount(%p, %p {.context=%p, "
                 ".read=%p, .prog=%p, .erase=%p, .sync=%p, "
                 ".read_size=%"PRIu32", .prog_size=%"PRIu32", "
@@ -3804,12 +3804,12 @@ int lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
     return 0;
 
 cleanup:
-    lfs_unmount(lfs);
+    _lfs_unmount(lfs);
     LFS_TRACE("lfs_mount -> %d", err);
     return err;
 }
 
-int lfs_unmount(lfs_t *lfs) {
+int _lfs_unmount(lfs_t *lfs) {
     LFS_TRACE("lfs_unmount(%p)", (void*)lfs);
     int err = lfs_deinit(lfs);
     LFS_TRACE("lfs_unmount -> %d", err);
@@ -3914,7 +3914,7 @@ int lfs_fs_traverseraw(lfs_t *lfs,
     return 0;
 }
 
-int lfs_fs_traverse(lfs_t *lfs,
+int _lfs_fs_traverse(lfs_t *lfs,
         int (*cb)(void *data, lfs_block_t block), void *data) {
     LFS_TRACE("lfs_fs_traverse(%p, %p, %p)",
             (void*)lfs, (void*)(uintptr_t)cb, data);
@@ -4235,7 +4235,7 @@ static int lfs_fs_size_count(void *p, lfs_block_t block) {
     return 0;
 }
 
-lfs_ssize_t lfs_fs_size(lfs_t *lfs) {
+lfs_ssize_t _lfs_fs_size(lfs_t *lfs) {
     LFS_TRACE("lfs_fs_size(%p)", (void*)lfs);
     lfs_size_t size = 0;
     int err = lfs_fs_traverseraw(lfs, lfs_fs_size_count, &size, false);
@@ -4669,7 +4669,7 @@ static int lfs1_unmount(lfs_t *lfs) {
 }
 
 /// v1 migration ///
-int lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg) {
+int _lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg) {
     LFS_TRACE("lfs_migrate(%p, %p {.context=%p, "
                 ".read=%p, .prog=%p, .erase=%p, .sync=%p, "
                 ".read_size=%"PRIu32", .prog_size=%"PRIu32", "
@@ -4910,4 +4910,125 @@ cleanup:
     return err;
 }
 
+#endif
+
+#if LFS_THREAD_SAFE
+
+#define CREATE_LFS_TS_1(ret, function, b_type, b) \
+    ret _ts ## function(b_type b)                 \
+    {                                             \
+        int err = lfs->cfg->lock(lfs->cfg);       \
+        if (err)                                  \
+        {                                         \
+            return err;                           \
+        }                                         \
+        err = function(b);                        \
+        lfs->cfg->unlock(lfs->cfg);               \
+        return err;                               \
+    }
+#define CREATE_LFS_TS_2(ret, function, b_type, b, c_type, c) \
+    ret _ts ## function(b_type b, c_type c)                  \
+    {                                                        \
+        int err = lfs->cfg->lock(lfs->cfg);                  \
+        if (err)                                             \
+        {                                                    \
+            return err;                                      \
+        }                                                    \
+        err = function(b, c);                                \
+        lfs->cfg->unlock(lfs->cfg);                          \
+        return err;                                          \
+    }
+#define CREATE_LFS_TS_2_CFG(ret, function, b_type, b, c_type, cfg) \
+    ret _ts ## function(b_type b, c_type cfg)                      \
+    {                                                              \
+        int err = cfg->lock(cfg);                                  \
+        if (err)                                                   \
+        {                                                          \
+            return err;                                            \
+        }                                                          \
+        err = function(b, cfg);                                    \
+        cfg->unlock(cfg);                                          \
+        return err;                                                \
+    }
+#define CREATE_LFS_TS_3(ret, function, b_type, b, c_type, c, d_type, d) \
+    ret _ts ## function(b_type b, c_type c, d_type d)                   \
+    {                                                                   \
+        int err = lfs->cfg->lock(lfs->cfg);                             \
+        if (err)                                                        \
+        {                                                               \
+            return err;                                                 \
+        }                                                               \
+        err = function(b, c, d);                                        \
+        lfs->cfg->unlock(lfs->cfg);                                     \
+        return err;                                                     \
+    }
+#define CREATE_LFS_TS_4(ret, function, b_type, b, c_type, c, d_type, d, e_type, e) \
+    ret _ts ## function(b_type b, c_type c, d_type d, e_type e)                    \
+    {                                                                              \
+        int err = lfs->cfg->lock(lfs->cfg);                                        \
+        if (err)                                                                   \
+        {                                                                          \
+            return err;                                                            \
+        }                                                                          \
+        err = function(b, c, d, e);                                                \
+        lfs->cfg->unlock(lfs->cfg);                                                \
+        return err;                                                                \
+    }
+#define CREATE_LFS_TS_5(ret, function, b_type, b, c_type, c, d_type, d, e_type, e, f_type, f) \
+    ret _ts ## function(b_type b, c_type c, d_type d, e_type e, f_type f)                     \
+    {                                                                                         \
+        int err = lfs->cfg->lock(lfs->cfg);                                                   \
+        if (err)                                                                              \
+        {                                                                                     \
+            return err;                                                                       \
+        }                                                                                     \
+        err = function(b, c, d, e, f);                                                        \
+        lfs->cfg->unlock(lfs->cfg);                                                           \
+        return err;                                                                           \
+    }
+
+int _ts_lfs_fs_traverse (lfs_t * lfs, int (* cb)(void * data, lfs_block_t block), void * data) {
+    int err = lfs->cfg->lock(lfs->cfg);
+    if (err)
+    {
+        return err;
+    }
+
+    err = _lfs_fs_traverse(lfs, cb, data);
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+
+CREATE_LFS_TS_2_CFG(int, _lfs_format,lfs_t *, lfs, const struct lfs_config *, config)
+CREATE_LFS_TS_2_CFG(int, _lfs_mount,lfs_t *, lfs, const struct lfs_config *, config)
+CREATE_LFS_TS_1(int, _lfs_unmount,lfs_t *, lfs)
+CREATE_LFS_TS_2(int, _lfs_remove,lfs_t *, lfs, const char *, path)
+CREATE_LFS_TS_3(int, _lfs_rename, lfs_t *, lfs, const char *, oldpath, const char *, newpath)
+CREATE_LFS_TS_3(int, _lfs_stat, lfs_t *, lfs, const char *, path, struct lfs_info *, info)
+CREATE_LFS_TS_5(lfs_ssize_t, _lfs_getattr, lfs_t *, lfs, const char *, path, uint8_t, type, void *, buffer, lfs_size_t, size)
+CREATE_LFS_TS_5(int, _lfs_setattr, lfs_t *, lfs, const char *, path, uint8_t, type, const void *, buffer, lfs_size_t, size)
+CREATE_LFS_TS_3(int, _lfs_removeattr, lfs_t *, lfs, const char *, path, uint8_t, type)
+CREATE_LFS_TS_4(int, _lfs_file_open, lfs_t *, lfs, lfs_file_t *, file, const char *, path, int, flags)
+CREATE_LFS_TS_5(int, _lfs_file_opencfg, lfs_t *, lfs, lfs_file_t *, file, const char *, path, int, flags, const struct lfs_file_config *, config)
+CREATE_LFS_TS_2(int, _lfs_file_close, lfs_t *, lfs, lfs_file_t *, file)
+CREATE_LFS_TS_2(int, _lfs_file_sync, lfs_t *, lfs, lfs_file_t *, file)
+CREATE_LFS_TS_4(lfs_ssize_t, _lfs_file_read, lfs_t *, lfs, lfs_file_t *, file, void *, buffer, lfs_size_t, size)
+CREATE_LFS_TS_4(lfs_ssize_t, _lfs_file_write, lfs_t *, lfs, lfs_file_t *, file, const void *, buffer, lfs_size_t, size)
+CREATE_LFS_TS_4(lfs_soff_t, _lfs_file_seek, lfs_t *, lfs, lfs_file_t *, file, lfs_soff_t, off, int, whence)
+CREATE_LFS_TS_3(int, _lfs_file_truncate, lfs_t *, lfs, lfs_file_t *, file, lfs_off_t, size)
+CREATE_LFS_TS_2(lfs_soff_t, _lfs_file_tell, lfs_t *, lfs, lfs_file_t *, file)
+CREATE_LFS_TS_2(int, _lfs_file_rewind, lfs_t *, lfs, lfs_file_t *, file)
+CREATE_LFS_TS_2(lfs_soff_t, _lfs_file_size, lfs_t *, lfs, lfs_file_t *, file)
+CREATE_LFS_TS_2(int, _lfs_mkdir, lfs_t *, lfs, const char *, path)
+CREATE_LFS_TS_3(int, _lfs_dir_open, lfs_t *, lfs, lfs_dir_t *, dir, const char *, path)
+CREATE_LFS_TS_2(int, _lfs_dir_close, lfs_t *, lfs, lfs_dir_t *, dir)
+CREATE_LFS_TS_3(int, _lfs_dir_read, lfs_t *, lfs, lfs_dir_t *, dir, struct lfs_info *, info)
+CREATE_LFS_TS_3(int, _lfs_dir_seek, lfs_t *, lfs, lfs_dir_t *, dir, lfs_off_t, off)
+CREATE_LFS_TS_2(lfs_soff_t, _lfs_dir_tell, lfs_t *, lfs, lfs_dir_t *, dir)
+CREATE_LFS_TS_2(int, _lfs_dir_rewind, lfs_t *, lfs, lfs_dir_t *, dir)
+CREATE_LFS_TS_1(lfs_ssize_t, _lfs_fs_size, lfs_t *, lfs)
+#ifdef LFS_MIGRATE
+CREATE_LFS_TS_2_CFG(int, _lfs_migrate, lfs_t *, lfs, const struct lfs_config *, cfg)
+#endif
 #endif

--- a/lfs.c
+++ b/lfs.c
@@ -1525,7 +1525,7 @@ static int lfs_dir_compact(lfs_t *lfs,
         if (lfs_pair_cmp(dir->pair, (const lfs_block_t[2]){0, 1}) == 0) {
             // oh no! we're writing too much to the superblock,
             // should we expand?
-            lfs_ssize_t res = _lfs_fs_size(lfs);
+            lfs_ssize_t res = lfs_fs_size_raw(lfs);
             if (res < 0) {
                 return res;
             }
@@ -1906,7 +1906,7 @@ compact:
 
 
 /// Top level directory operations ///
-int _lfs_mkdir(lfs_t *lfs, const char *path) {
+int lfs_mkdir_raw(lfs_t *lfs, const char *path) {
     LFS_TRACE("lfs_mkdir(%p, \"%s\")", (void*)lfs, path);
     // deorphan if we haven't yet, needed at most once after poweron
     int err = lfs_fs_forceconsistency(lfs);
@@ -2005,7 +2005,7 @@ int _lfs_mkdir(lfs_t *lfs, const char *path) {
     return 0;
 }
 
-int _lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
+int lfs_dir_open_raw(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
     LFS_TRACE("lfs_dir_open(%p, %p, \"%s\")", (void*)lfs, (void*)dir, path);
     lfs_stag_t tag = lfs_dir_find(lfs, &dir->m, &path, NULL);
     if (tag < 0) {
@@ -2056,7 +2056,7 @@ int _lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
     return 0;
 }
 
-int _lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir) {
+int lfs_dir_close_raw(lfs_t *lfs, lfs_dir_t *dir) {
     LFS_TRACE("lfs_dir_close(%p, %p)", (void*)lfs, (void*)dir);
     // remove from list of mdirs
     for (struct lfs_mlist **p = &lfs->mlist; *p; p = &(*p)->next) {
@@ -2070,7 +2070,7 @@ int _lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir) {
     return 0;
 }
 
-int _lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
+int lfs_dir_read_raw(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
     LFS_TRACE("lfs_dir_read(%p, %p, %p)",
             (void*)lfs, (void*)dir, (void*)info);
     memset(info, 0, sizeof(*info));
@@ -2123,11 +2123,11 @@ int _lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
     return true;
 }
 
-int _lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
+int lfs_dir_seek_raw(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
     LFS_TRACE("lfs_dir_seek(%p, %p, %"PRIu32")",
             (void*)lfs, (void*)dir, off);
     // simply walk from head dir
-    int err = _lfs_dir_rewind(lfs, dir);
+    int err = lfs_dir_rewind_raw(lfs, dir);
     if (err) {
         LFS_TRACE("lfs_dir_seek -> %d", err);
         return err;
@@ -2166,14 +2166,14 @@ int _lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
     return 0;
 }
 
-lfs_soff_t _lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir) {
+lfs_soff_t lfs_dir_tell_raw(lfs_t *lfs, lfs_dir_t *dir) {
     LFS_TRACE("lfs_dir_tell(%p, %p)", (void*)lfs, (void*)dir);
     (void)lfs;
     LFS_TRACE("lfs_dir_tell -> %"PRId32, dir->pos);
     return dir->pos;
 }
 
-int _lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir) {
+int lfs_dir_rewind_raw(lfs_t *lfs, lfs_dir_t *dir) {
     LFS_TRACE("lfs_dir_rewind(%p, %p)", (void*)lfs, (void*)dir);
     // reload the head dir
     int err = lfs_dir_fetch(lfs, &dir->m, dir->head);
@@ -2380,7 +2380,7 @@ static int lfs_ctz_traverse(lfs_t *lfs,
 
 
 /// Top level file operations ///
-int _lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
+int lfs_file_opencfg_raw(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags,
         const struct lfs_file_config *cfg) {
     LFS_TRACE("lfs_file_opencfg(%p, %p, \"%s\", %x, %p {"
@@ -2529,26 +2529,26 @@ int _lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
 cleanup:
     // clean up lingering resources
     file->flags |= LFS_F_ERRED;
-    _lfs_file_close(lfs, file);
+    lfs_file_close_raw(lfs, file);
     LFS_TRACE("lfs_file_opencfg -> %d", err);
     return err;
 }
 
-int _lfs_file_open(lfs_t *lfs, lfs_file_t *file,
+int lfs_file_open_raw(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags) {
     LFS_TRACE("lfs_file_open(%p, %p, \"%s\", %x)",
             (void*)lfs, (void*)file, path, flags);
     static const struct lfs_file_config defaults = {0};
-    int err = _lfs_file_opencfg(lfs, file, path, flags, &defaults);
+    int err = lfs_file_opencfg_raw(lfs, file, path, flags, &defaults);
     LFS_TRACE("lfs_file_open -> %d", err);
     return err;
 }
 
-int _lfs_file_close(lfs_t *lfs, lfs_file_t *file) {
+int lfs_file_close_raw(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_close(%p, %p)", (void*)lfs, (void*)file);
     LFS_ASSERT(file->flags & LFS_F_OPENED);
 
-    int err = _lfs_file_sync(lfs, file);
+    int err = lfs_file_sync_raw(lfs, file);
 
     // remove from list of mdirs
     for (struct lfs_mlist **p = &lfs->mlist; *p; p = &(*p)->next) {
@@ -2679,12 +2679,12 @@ static int lfs_file_flush(lfs_t *lfs, lfs_file_t *file) {
                 // copy over a byte at a time, leave it up to caching
                 // to make this efficient
                 uint8_t data;
-                lfs_ssize_t res = _lfs_file_read(lfs, &orig, &data, 1);
+                lfs_ssize_t res = lfs_file_read_raw(lfs, &orig, &data, 1);
                 if (res < 0) {
                     return res;
                 }
 
-                res = _lfs_file_write(lfs, file, &data, 1);
+                res = lfs_file_write_raw(lfs, file, &data, 1);
                 if (res < 0) {
                     return res;
                 }
@@ -2731,7 +2731,7 @@ relocate:
     return 0;
 }
 
-int _lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
+int lfs_file_sync_raw(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_sync(%p, %p)", (void*)lfs, (void*)file);
     LFS_ASSERT(file->flags & LFS_F_OPENED);
 
@@ -2788,7 +2788,7 @@ int _lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
     return 0;
 }
 
-lfs_ssize_t _lfs_file_read(lfs_t *lfs, lfs_file_t *file,
+lfs_ssize_t lfs_file_read_raw(lfs_t *lfs, lfs_file_t *file,
         void *buffer, lfs_size_t size) {
     LFS_TRACE("lfs_file_read(%p, %p, %p, %"PRIu32")",
             (void*)lfs, (void*)file, buffer, size);
@@ -2868,7 +2868,7 @@ lfs_ssize_t _lfs_file_read(lfs_t *lfs, lfs_file_t *file,
     return size;
 }
 
-lfs_ssize_t _lfs_file_write(lfs_t *lfs, lfs_file_t *file,
+lfs_ssize_t lfs_file_write_raw(lfs_t *lfs, lfs_file_t *file,
         const void *buffer, lfs_size_t size) {
     LFS_TRACE("lfs_file_write(%p, %p, %p, %"PRIu32")",
             (void*)lfs, (void*)file, buffer, size);
@@ -2903,7 +2903,7 @@ lfs_ssize_t _lfs_file_write(lfs_t *lfs, lfs_file_t *file,
         file->pos = file->ctz.size;
 
         while (file->pos < pos) {
-            lfs_ssize_t res = _lfs_file_write(lfs, file, &(uint8_t){0}, 1);
+            lfs_ssize_t res = lfs_file_write_raw(lfs, file, &(uint8_t){0}, 1);
             if (res < 0) {
                 LFS_TRACE("lfs_file_write -> %"PRId32, res);
                 return res;
@@ -2999,7 +2999,7 @@ relocate:
     return size;
 }
 
-lfs_soff_t _lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
+lfs_soff_t lfs_file_seek_raw(lfs_t *lfs, lfs_file_t *file,
         lfs_soff_t off, int whence) {
     LFS_TRACE("lfs_file_seek(%p, %p, %"PRId32", %d)",
             (void*)lfs, (void*)file, off, whence);
@@ -3034,7 +3034,7 @@ lfs_soff_t _lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
     return npos;
 }
 
-int _lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
+int lfs_file_truncate_raw(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     LFS_TRACE("lfs_file_truncate(%p, %p, %"PRIu32")",
             (void*)lfs, (void*)file, size);
     LFS_ASSERT(file->flags & LFS_F_OPENED);
@@ -3046,7 +3046,7 @@ int _lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     }
 
     lfs_off_t pos = file->pos;
-    lfs_off_t oldsize = _lfs_file_size(lfs, file);
+    lfs_off_t oldsize = lfs_file_size_raw(lfs, file);
     if (size < oldsize) {
         // need to flush since directly changing metadata
         int err = lfs_file_flush(lfs, file);
@@ -3070,7 +3070,7 @@ int _lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     } else if (size > oldsize) {
         // flush+seek if not already at end
         if (file->pos != oldsize) {
-            lfs_soff_t res = _lfs_file_seek(lfs, file, 0, LFS_SEEK_END);
+            lfs_soff_t res = lfs_file_seek_raw(lfs, file, 0, LFS_SEEK_END);
             if (res < 0) {
                 LFS_TRACE("lfs_file_truncate -> %"PRId32, res);
                 return (int)res;
@@ -3079,7 +3079,7 @@ int _lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
 
         // fill with zeros
         while (file->pos < size) {
-            lfs_ssize_t res = _lfs_file_write(lfs, file, &(uint8_t){0}, 1);
+            lfs_ssize_t res = lfs_file_write_raw(lfs, file, &(uint8_t){0}, 1);
             if (res < 0) {
                 LFS_TRACE("lfs_file_truncate -> %"PRId32, res);
                 return (int)res;
@@ -3088,7 +3088,7 @@ int _lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     }
 
     // restore pos
-    lfs_soff_t res = _lfs_file_seek(lfs, file, pos, LFS_SEEK_SET);
+    lfs_soff_t res = lfs_file_seek_raw(lfs, file, pos, LFS_SEEK_SET);
     if (res < 0) {
       LFS_TRACE("lfs_file_truncate -> %"PRId32, res);
       return (int)res;
@@ -3098,7 +3098,7 @@ int _lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     return 0;
 }
 
-lfs_soff_t _lfs_file_tell(lfs_t *lfs, lfs_file_t *file) {
+lfs_soff_t lfs_file_tell_raw(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_tell(%p, %p)", (void*)lfs, (void*)file);
     LFS_ASSERT(file->flags & LFS_F_OPENED);
     (void)lfs;
@@ -3106,9 +3106,9 @@ lfs_soff_t _lfs_file_tell(lfs_t *lfs, lfs_file_t *file) {
     return file->pos;
 }
 
-int _lfs_file_rewind(lfs_t *lfs, lfs_file_t *file) {
+int lfs_file_rewind_raw(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_rewind(%p, %p)", (void*)lfs, (void*)file);
-    lfs_soff_t res = _lfs_file_seek(lfs, file, 0, LFS_SEEK_SET);
+    lfs_soff_t res = lfs_file_seek_raw(lfs, file, 0, LFS_SEEK_SET);
     if (res < 0) {
         LFS_TRACE("lfs_file_rewind -> %"PRId32, res);
         return (int)res;
@@ -3118,7 +3118,7 @@ int _lfs_file_rewind(lfs_t *lfs, lfs_file_t *file) {
     return 0;
 }
 
-lfs_soff_t _lfs_file_size(lfs_t *lfs, lfs_file_t *file) {
+lfs_soff_t lfs_file_size_raw(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_size(%p, %p)", (void*)lfs, (void*)file);
     LFS_ASSERT(file->flags & LFS_F_OPENED);
     (void)lfs;
@@ -3134,7 +3134,7 @@ lfs_soff_t _lfs_file_size(lfs_t *lfs, lfs_file_t *file) {
 
 
 /// General fs operations ///
-int _lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info) {
+int lfs_stat_raw(lfs_t *lfs, const char *path, struct lfs_info *info) {
     LFS_TRACE("lfs_stat(%p, \"%s\", %p)", (void*)lfs, path, (void*)info);
     lfs_mdir_t cwd;
     lfs_stag_t tag = lfs_dir_find(lfs, &cwd, &path, NULL);
@@ -3148,7 +3148,7 @@ int _lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info) {
     return err;
 }
 
-int _lfs_remove(lfs_t *lfs, const char *path) {
+int lfs_remove_raw(lfs_t *lfs, const char *path) {
     LFS_TRACE("lfs_remove(%p, \"%s\")", (void*)lfs, path);
     // deorphan if we haven't yet, needed at most once after poweron
     int err = lfs_fs_forceconsistency(lfs);
@@ -3229,7 +3229,7 @@ int _lfs_remove(lfs_t *lfs, const char *path) {
     return 0;
 }
 
-int _lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
+int lfs_rename_raw(lfs_t *lfs, const char *oldpath, const char *newpath) {
     LFS_TRACE("lfs_rename(%p, \"%s\", \"%s\")", (void*)lfs, oldpath, newpath);
 
     // deorphan if we haven't yet, needed at most once after poweron
@@ -3374,7 +3374,7 @@ int _lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
     return 0;
 }
 
-lfs_ssize_t _lfs_getattr(lfs_t *lfs, const char *path,
+lfs_ssize_t lfs_getattr_raw(lfs_t *lfs, const char *path,
         uint8_t type, void *buffer, lfs_size_t size) {
     LFS_TRACE("lfs_getattr(%p, \"%s\", %"PRIu8", %p, %"PRIu32")",
             (void*)lfs, path, type, buffer, size);
@@ -3437,7 +3437,7 @@ static int lfs_commitattr(lfs_t *lfs, const char *path,
             {LFS_MKTAG(LFS_TYPE_USERATTR + type, id, size), buffer}));
 }
 
-int _lfs_setattr(lfs_t *lfs, const char *path,
+int lfs_setattr_raw(lfs_t *lfs, const char *path,
         uint8_t type, const void *buffer, lfs_size_t size) {
     LFS_TRACE("lfs_setattr(%p, \"%s\", %"PRIu8", %p, %"PRIu32")",
             (void*)lfs, path, type, buffer, size);
@@ -3451,7 +3451,7 @@ int _lfs_setattr(lfs_t *lfs, const char *path,
     return err;
 }
 
-int _lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type) {
+int lfs_removeattr_raw(lfs_t *lfs, const char *path, uint8_t type) {
     LFS_TRACE("lfs_removeattr(%p, \"%s\", %"PRIu8")", (void*)lfs, path, type);
     int err = lfs_commitattr(lfs, path, type, NULL, 0x3ff);
     LFS_TRACE("lfs_removeattr -> %d", err);
@@ -3584,7 +3584,7 @@ static int lfs_deinit(lfs_t *lfs) {
     return 0;
 }
 
-int _lfs_format(lfs_t *lfs, const struct lfs_config *cfg) {
+int lfs_format_raw(lfs_t *lfs, const struct lfs_config *cfg) {
     LFS_TRACE("lfs_format(%p, %p {.context=%p, "
                 ".read=%p, .prog=%p, .erase=%p, .sync=%p, "
                 ".read_size=%"PRIu32", .prog_size=%"PRIu32", "
@@ -3665,7 +3665,7 @@ cleanup:
     return err;
 }
 
-int _lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
+int lfs_mount_raw(lfs_t *lfs, const struct lfs_config *cfg) {
     LFS_TRACE("lfs_mount(%p, %p {.context=%p, "
                 ".read=%p, .prog=%p, .erase=%p, .sync=%p, "
                 ".read_size=%"PRIu32", .prog_size=%"PRIu32", "
@@ -3804,12 +3804,12 @@ int _lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
     return 0;
 
 cleanup:
-    _lfs_unmount(lfs);
+    lfs_unmount_raw(lfs);
     LFS_TRACE("lfs_mount -> %d", err);
     return err;
 }
 
-int _lfs_unmount(lfs_t *lfs) {
+int lfs_unmount_raw(lfs_t *lfs) {
     LFS_TRACE("lfs_unmount(%p)", (void*)lfs);
     int err = lfs_deinit(lfs);
     LFS_TRACE("lfs_unmount -> %d", err);
@@ -3914,7 +3914,7 @@ int lfs_fs_traverseraw(lfs_t *lfs,
     return 0;
 }
 
-int _lfs_fs_traverse(lfs_t *lfs,
+int lfs_fs_traverse_raw(lfs_t *lfs,
         int (*cb)(void *data, lfs_block_t block), void *data) {
     LFS_TRACE("lfs_fs_traverse(%p, %p, %p)",
             (void*)lfs, (void*)(uintptr_t)cb, data);
@@ -4235,7 +4235,7 @@ static int lfs_fs_size_count(void *p, lfs_block_t block) {
     return 0;
 }
 
-lfs_ssize_t _lfs_fs_size(lfs_t *lfs) {
+lfs_ssize_t lfs_fs_size_raw(lfs_t *lfs) {
     LFS_TRACE("lfs_fs_size(%p)", (void*)lfs);
     lfs_size_t size = 0;
     int err = lfs_fs_traverseraw(lfs, lfs_fs_size_count, &size, false);
@@ -4669,7 +4669,7 @@ static int lfs1_unmount(lfs_t *lfs) {
 }
 
 /// v1 migration ///
-int _lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg) {
+int lfs_migrate_raw(lfs_t *lfs, const struct lfs_config *cfg) {
     LFS_TRACE("lfs_migrate(%p, %p {.context=%p, "
                 ".read=%p, .prog=%p, .erase=%p, .sync=%p, "
                 ".read_size=%"PRIu32", .prog_size=%"PRIu32", "
@@ -4914,387 +4914,387 @@ cleanup:
 
 #if LFS_THREAD_SAFE
 
-int _ts_lfs_format(lfs_t *lfs, const struct lfs_config *config)
+int lfs_format_ts(lfs_t *lfs, const struct lfs_config *config)
 {
     int err = config->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_format(lfs, config);
+    err = lfs_format_raw(lfs, config);
     config->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_mount(lfs_t *lfs, const struct lfs_config *config)
+int lfs_mount_ts(lfs_t *lfs, const struct lfs_config *config)
 {
     int err = config->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_mount(lfs, config);
+    err = lfs_mount_raw(lfs, config);
     config->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_unmount(lfs_t *lfs)
+int lfs_unmount_ts(lfs_t *lfs)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_unmount(lfs);
+    err = lfs_unmount_raw(lfs);
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_remove(lfs_t *lfs, const char *path)
+int lfs_remove_ts(lfs_t *lfs, const char *path)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_remove(lfs, path);
+    err = lfs_remove_raw(lfs, path);
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath)
+int lfs_rename_ts(lfs_t *lfs, const char *oldpath, const char *newpath)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_rename(lfs, oldpath, newpath);
+    err = lfs_rename_raw(lfs, oldpath, newpath);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info)
+int lfs_stat_ts(lfs_t *lfs, const char *path, struct lfs_info *info)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_stat(lfs, path, info);
+    err = lfs_stat_raw(lfs, path, info);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_ssize_t _ts_lfs_getattr(lfs_t *lfs, const char *path, uint8_t type, void *buffer, lfs_size_t size)
+lfs_ssize_t lfs_getattr_ts(lfs_t *lfs, const char *path, uint8_t type, void *buffer, lfs_size_t size)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_getattr(lfs, path, type, buffer, size);
+    err = lfs_getattr_raw(lfs, path, type, buffer, size);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_setattr(lfs_t *lfs, const char *path, uint8_t type, const void *buffer, lfs_size_t size)
+int lfs_setattr_ts(lfs_t *lfs, const char *path, uint8_t type, const void *buffer, lfs_size_t size)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_setattr(lfs, path, type, buffer, size);
+    err = lfs_setattr_raw(lfs, path, type, buffer, size);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type)
+int lfs_removeattr_ts(lfs_t *lfs, const char *path, uint8_t type)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_removeattr(lfs, path, type);
+    err = lfs_removeattr_raw(lfs, path, type);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_file_open(lfs_t *lfs, lfs_file_t *file, const char *path, int flags)
+int lfs_file_open_ts(lfs_t *lfs, lfs_file_t *file, const char *path, int flags)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_file_open(lfs, file, path, flags);
+    err = lfs_file_open_raw(lfs, file, path, flags);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, const struct lfs_file_config *config)
+int lfs_file_opencfg_ts(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, const struct lfs_file_config *config)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_file_opencfg(lfs, file, path, flags, config);
+    err = lfs_file_opencfg_raw(lfs, file, path, flags, config);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_file_close(lfs_t *lfs, lfs_file_t *file)
+int lfs_file_close_ts(lfs_t *lfs, lfs_file_t *file)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_file_close(lfs, file);
+    err = lfs_file_close_raw(lfs, file);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_file_sync(lfs_t *lfs, lfs_file_t *file)
+int lfs_file_sync_ts(lfs_t *lfs, lfs_file_t *file)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_file_sync(lfs, file);
+    err = lfs_file_sync_raw(lfs, file);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_ssize_t _ts_lfs_file_read(lfs_t *lfs, lfs_file_t *file, void *buffer, lfs_size_t size)
+lfs_ssize_t lfs_file_read_ts(lfs_t *lfs, lfs_file_t *file, void *buffer, lfs_size_t size)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_file_read(lfs, file, buffer, size);
+    err = lfs_file_read_raw(lfs, file, buffer, size);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_ssize_t _ts_lfs_file_write(lfs_t *lfs, lfs_file_t *file, const void *buffer, lfs_size_t size)
+lfs_ssize_t lfs_file_write_ts(lfs_t *lfs, lfs_file_t *file, const void *buffer, lfs_size_t size)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_file_write(lfs, file, buffer, size);
+    err = lfs_file_write_raw(lfs, file, buffer, size);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_soff_t _ts_lfs_file_seek(lfs_t *lfs, lfs_file_t *file, lfs_soff_t off, int whence)
+lfs_soff_t lfs_file_seek_ts(lfs_t *lfs, lfs_file_t *file, lfs_soff_t off, int whence)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_file_seek(lfs, file, off, whence);
+    err = lfs_file_seek_raw(lfs, file, off, whence);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size)
+int lfs_file_truncate_ts(lfs_t *lfs, lfs_file_t *file, lfs_off_t size)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_file_truncate(lfs, file, size);
+    err = lfs_file_truncate_raw(lfs, file, size);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_soff_t _ts_lfs_file_tell(lfs_t *lfs, lfs_file_t *file)
+lfs_soff_t lfs_file_tell_ts(lfs_t *lfs, lfs_file_t *file)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_file_tell(lfs, file);
+    err = lfs_file_tell_raw(lfs, file);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_file_rewind(lfs_t *lfs, lfs_file_t *file)
+int lfs_file_rewind_ts(lfs_t *lfs, lfs_file_t *file)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_file_rewind(lfs, file);
+    err = lfs_file_rewind_raw(lfs, file);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_soff_t _ts_lfs_file_size(lfs_t *lfs, lfs_file_t *file)
+lfs_soff_t lfs_file_size_ts(lfs_t *lfs, lfs_file_t *file)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_file_size(lfs, file);
+    err = lfs_file_size_raw(lfs, file);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_mkdir(lfs_t *lfs, const char *path)
+int lfs_mkdir_ts(lfs_t *lfs, const char *path)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_mkdir(lfs, path);
+    err = lfs_mkdir_raw(lfs, path);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path)
+int lfs_dir_open_ts(lfs_t *lfs, lfs_dir_t *dir, const char *path)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_dir_open(lfs, dir, path);
+    err = lfs_dir_open_raw(lfs, dir, path);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir)
+int lfs_dir_close_ts(lfs_t *lfs, lfs_dir_t *dir)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_dir_close(lfs, dir);
+    err = lfs_dir_close_raw(lfs, dir);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info)
+int lfs_dir_read_ts(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_dir_read(lfs, dir, info);
+    err = lfs_dir_read_raw(lfs, dir, info);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off)
+int lfs_dir_seek_ts(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_dir_seek(lfs, dir, off);
+    err = lfs_dir_seek_raw(lfs, dir, off);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_soff_t _ts_lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir)
+lfs_soff_t lfs_dir_tell_ts(lfs_t *lfs, lfs_dir_t *dir)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_dir_tell(lfs, dir);
+    err = lfs_dir_tell_raw(lfs, dir);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir)
+int lfs_dir_rewind_ts(lfs_t *lfs, lfs_dir_t *dir)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_dir_rewind(lfs, dir);
+    err = lfs_dir_rewind_raw(lfs, dir);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_ssize_t _ts_lfs_fs_size(lfs_t *lfs)
+lfs_ssize_t lfs_fs_size_ts(lfs_t *lfs)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_fs_size(lfs);
+    err = lfs_fs_size_raw(lfs);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data)
+int lfs_fs_traverse_ts(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_fs_traverse(lfs, cb, data);
+    err = lfs_fs_traverse_raw(lfs, cb, data);
     
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int _ts_lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg)
+int lfs_migrate_ts(lfs_t *lfs, const struct lfs_config *cfg)
 {
     int err = lfs->cfg->lock(lfs->cfg);
     if(err)
     {
         return err;
     }
-    err = lfs_migrate(lfs, cfg);
+    err = lfs_migrate_raw(lfs, cfg);
     
     lfs->cfg->unlock(lfs->cfg);
 

--- a/lfs.c
+++ b/lfs.c
@@ -4912,138 +4912,6 @@ cleanup:
 
 #endif
 
-#if !LFS_THREADSAFE
-
-int lfs_format (lfs_t * lfs, const struct lfs_config * config) {
-    return lfs_format_raw(lfs, config);
-}
-
-int lfs_mount (lfs_t * lfs, const struct lfs_config * config) {
-    return lfs_mount_raw(lfs, config);
-}
-
-int lfs_unmount (lfs_t * lfs) {
-    return lfs_unmount_raw(lfs);
-}
-
-int lfs_remove (lfs_t * lfs, const char * path) {
-    return lfs_remove_raw(lfs, path);
-}
-
-int lfs_rename (lfs_t * lfs, const char * oldpath, const char * newpath) {
-    return lfs_rename_raw(lfs, oldpath, newpath);
-}
-
-int lfs_stat (lfs_t * lfs, const char * path, struct lfs_info * info) {
-    return lfs_stat_raw(lfs, path, info);
-}
-
-lfs_ssize_t lfs_getattr (lfs_t * lfs, const char * path, uint8_t type, void * buffer, lfs_size_t size) {
-    return lfs_getattr_raw(lfs, path, type, buffer, size);
-}
-
-int lfs_setattr (lfs_t * lfs, const char * path, uint8_t type, const void * buffer, lfs_size_t size) {
-    return lfs_setattr_raw(lfs, path, type, buffer, size);
-}
-
-int lfs_removeattr (lfs_t * lfs, const char * path, uint8_t type) {
-    return lfs_removeattr_raw(lfs, path, type);
-}
-
-int lfs_file_open (lfs_t * lfs, lfs_file_t * file, const char * path, int flags) {
-    return lfs_file_open_raw(lfs, file, path, flags);
-}
-
-int lfs_file_opencfg (lfs_t                        * lfs,
-                         lfs_file_t                   * file,
-                         const char                   * path,
-                         int                            flags,
-                         const struct lfs_file_config * config) {
-    return lfs_file_opencfg_raw(lfs, file, path, flags, config);
-}
-
-int lfs_file_close (lfs_t * lfs, lfs_file_t * file) {
-    return lfs_file_close_raw(lfs, file);
-}
-
-int lfs_file_sync (lfs_t * lfs, lfs_file_t * file) {
-    return lfs_file_sync_raw(lfs, file);
-}
-
-lfs_ssize_t lfs_file_read (lfs_t * lfs, lfs_file_t * file, void * buffer, lfs_size_t size) {
-    return lfs_file_read_raw(lfs, file, buffer, size);
-}
-
-lfs_ssize_t lfs_file_write (lfs_t * lfs, lfs_file_t * file, const void * buffer, lfs_size_t size) {
-    return lfs_file_write_raw(lfs, file, buffer, size);
-}
-
-lfs_soff_t lfs_file_seek (lfs_t * lfs, lfs_file_t * file, lfs_soff_t off, int whence) {
-    return lfs_file_seek_raw(lfs, file, off, whence);
-}
-
-int lfs_file_truncate (lfs_t * lfs, lfs_file_t * file, lfs_off_t size) {
-    return lfs_file_truncate_raw(lfs, file, size);
-}
-
-lfs_soff_t lfs_file_tell (lfs_t * lfs, lfs_file_t * file) {
-    return lfs_file_tell_raw(lfs, file);
-}
-
-int lfs_file_rewind (lfs_t * lfs, lfs_file_t * file) {
-    return lfs_file_rewind_raw(lfs, file);
-}
-
-lfs_soff_t lfs_file_size (lfs_t * lfs, lfs_file_t * file) {
-    return lfs_file_size_raw(lfs, file);
-}
-
-int lfs_mkdir (lfs_t * lfs, const char * path) {
-    return lfs_mkdir_raw(lfs, path);
-}
-
-int lfs_dir_open (lfs_t * lfs, lfs_dir_t * dir, const char * path) {
-    return lfs_dir_open_raw(lfs, dir, path);
-}
-
-int lfs_dir_close (lfs_t * lfs, lfs_dir_t * dir) {
-    return lfs_dir_close_raw(lfs, dir);
-}
-
-int lfs_dir_read (lfs_t * lfs, lfs_dir_t * dir, struct lfs_info * info) {
-    return lfs_dir_read_raw(lfs, dir, info);
-}
-
-int lfs_dir_seek (lfs_t * lfs, lfs_dir_t * dir, lfs_off_t off) {
-    return lfs_dir_seek_raw(lfs, dir, off);
-}
-
-lfs_soff_t lfs_dir_tell (lfs_t * lfs, lfs_dir_t * dir) {
-    return lfs_dir_tell_raw(lfs, dir);
-}
-
-int lfs_dir_rewind (lfs_t * lfs, lfs_dir_t * dir) {
-    return lfs_dir_rewind_raw(lfs, dir);
-}
-
-lfs_ssize_t lfs_fs_size (lfs_t * lfs) {
-    return lfs_fs_size_raw(lfs);
-}
-
-int lfs_fs_traverse (lfs_t * lfs, int (* cb)(void *, lfs_block_t), void * data) {
-    return lfs_fs_traverse_raw(lfs, cb, data);
-}
-
-#ifdef LFS_MIGRATE
-
-int lfs_migrate (lfs_t * lfs, const struct lfs_config * cfg) {
-    return lfs_migrate_raw(lfs, cfg);
-}
-
-#endif
-
-#endif
-
 #if LFS_THREADSAFE
 
 int lfs_format (lfs_t * lfs, const struct lfs_config * config) {
@@ -5466,6 +5334,135 @@ int lfs_migrate (lfs_t * lfs, const struct lfs_config * cfg) {
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
+}
+
+#endif
+#else
+
+int lfs_format (lfs_t * lfs, const struct lfs_config * config) {
+    return lfs_format_raw(lfs, config);
+}
+
+int lfs_mount (lfs_t * lfs, const struct lfs_config * config) {
+    return lfs_mount_raw(lfs, config);
+}
+
+int lfs_unmount (lfs_t * lfs) {
+    return lfs_unmount_raw(lfs);
+}
+
+int lfs_remove (lfs_t * lfs, const char * path) {
+    return lfs_remove_raw(lfs, path);
+}
+
+int lfs_rename (lfs_t * lfs, const char * oldpath, const char * newpath) {
+    return lfs_rename_raw(lfs, oldpath, newpath);
+}
+
+int lfs_stat (lfs_t * lfs, const char * path, struct lfs_info * info) {
+    return lfs_stat_raw(lfs, path, info);
+}
+
+lfs_ssize_t lfs_getattr (lfs_t * lfs, const char * path, uint8_t type, void * buffer, lfs_size_t size) {
+    return lfs_getattr_raw(lfs, path, type, buffer, size);
+}
+
+int lfs_setattr (lfs_t * lfs, const char * path, uint8_t type, const void * buffer, lfs_size_t size) {
+    return lfs_setattr_raw(lfs, path, type, buffer, size);
+}
+
+int lfs_removeattr (lfs_t * lfs, const char * path, uint8_t type) {
+    return lfs_removeattr_raw(lfs, path, type);
+}
+
+int lfs_file_open (lfs_t * lfs, lfs_file_t * file, const char * path, int flags) {
+    return lfs_file_open_raw(lfs, file, path, flags);
+}
+
+int lfs_file_opencfg (lfs_t                        * lfs,
+                         lfs_file_t                   * file,
+                         const char                   * path,
+                         int                            flags,
+                         const struct lfs_file_config * config) {
+    return lfs_file_opencfg_raw(lfs, file, path, flags, config);
+}
+
+int lfs_file_close (lfs_t * lfs, lfs_file_t * file) {
+    return lfs_file_close_raw(lfs, file);
+}
+
+int lfs_file_sync (lfs_t * lfs, lfs_file_t * file) {
+    return lfs_file_sync_raw(lfs, file);
+}
+
+lfs_ssize_t lfs_file_read (lfs_t * lfs, lfs_file_t * file, void * buffer, lfs_size_t size) {
+    return lfs_file_read_raw(lfs, file, buffer, size);
+}
+
+lfs_ssize_t lfs_file_write (lfs_t * lfs, lfs_file_t * file, const void * buffer, lfs_size_t size) {
+    return lfs_file_write_raw(lfs, file, buffer, size);
+}
+
+lfs_soff_t lfs_file_seek (lfs_t * lfs, lfs_file_t * file, lfs_soff_t off, int whence) {
+    return lfs_file_seek_raw(lfs, file, off, whence);
+}
+
+int lfs_file_truncate (lfs_t * lfs, lfs_file_t * file, lfs_off_t size) {
+    return lfs_file_truncate_raw(lfs, file, size);
+}
+
+lfs_soff_t lfs_file_tell (lfs_t * lfs, lfs_file_t * file) {
+    return lfs_file_tell_raw(lfs, file);
+}
+
+int lfs_file_rewind (lfs_t * lfs, lfs_file_t * file) {
+    return lfs_file_rewind_raw(lfs, file);
+}
+
+lfs_soff_t lfs_file_size (lfs_t * lfs, lfs_file_t * file) {
+    return lfs_file_size_raw(lfs, file);
+}
+
+int lfs_mkdir (lfs_t * lfs, const char * path) {
+    return lfs_mkdir_raw(lfs, path);
+}
+
+int lfs_dir_open (lfs_t * lfs, lfs_dir_t * dir, const char * path) {
+    return lfs_dir_open_raw(lfs, dir, path);
+}
+
+int lfs_dir_close (lfs_t * lfs, lfs_dir_t * dir) {
+    return lfs_dir_close_raw(lfs, dir);
+}
+
+int lfs_dir_read (lfs_t * lfs, lfs_dir_t * dir, struct lfs_info * info) {
+    return lfs_dir_read_raw(lfs, dir, info);
+}
+
+int lfs_dir_seek (lfs_t * lfs, lfs_dir_t * dir, lfs_off_t off) {
+    return lfs_dir_seek_raw(lfs, dir, off);
+}
+
+lfs_soff_t lfs_dir_tell (lfs_t * lfs, lfs_dir_t * dir) {
+    return lfs_dir_tell_raw(lfs, dir);
+}
+
+int lfs_dir_rewind (lfs_t * lfs, lfs_dir_t * dir) {
+    return lfs_dir_rewind_raw(lfs, dir);
+}
+
+lfs_ssize_t lfs_fs_size (lfs_t * lfs) {
+    return lfs_fs_size_raw(lfs);
+}
+
+int lfs_fs_traverse (lfs_t * lfs, int (* cb)(void *, lfs_block_t), void * data) {
+    return lfs_fs_traverse_raw(lfs, cb, data);
+}
+
+#ifdef LFS_MIGRATE
+
+int lfs_migrate (lfs_t * lfs, const struct lfs_config * cfg) {
+    return lfs_migrate_raw(lfs, cfg);
 }
 
 #endif

--- a/lfs.c
+++ b/lfs.c
@@ -4914,121 +4914,390 @@ cleanup:
 
 #if LFS_THREAD_SAFE
 
-#define CREATE_LFS_TS_1(ret, function, b_type, b) \
-    ret _ts ## function(b_type b)                 \
-    {                                             \
-        int err = lfs->cfg->lock(lfs->cfg);       \
-        if (err)                                  \
-        {                                         \
-            return err;                           \
-        }                                         \
-        err = function(b);                        \
-        lfs->cfg->unlock(lfs->cfg);               \
-        return err;                               \
-    }
-#define CREATE_LFS_TS_2(ret, function, b_type, b, c_type, c) \
-    ret _ts ## function(b_type b, c_type c)                  \
-    {                                                        \
-        int err = lfs->cfg->lock(lfs->cfg);                  \
-        if (err)                                             \
-        {                                                    \
-            return err;                                      \
-        }                                                    \
-        err = function(b, c);                                \
-        lfs->cfg->unlock(lfs->cfg);                          \
-        return err;                                          \
-    }
-#define CREATE_LFS_TS_2_CFG(ret, function, b_type, b, c_type, cfg) \
-    ret _ts ## function(b_type b, c_type cfg)                      \
-    {                                                              \
-        int err = cfg->lock(cfg);                                  \
-        if (err)                                                   \
-        {                                                          \
-            return err;                                            \
-        }                                                          \
-        err = function(b, cfg);                                    \
-        cfg->unlock(cfg);                                          \
-        return err;                                                \
-    }
-#define CREATE_LFS_TS_3(ret, function, b_type, b, c_type, c, d_type, d) \
-    ret _ts ## function(b_type b, c_type c, d_type d)                   \
-    {                                                                   \
-        int err = lfs->cfg->lock(lfs->cfg);                             \
-        if (err)                                                        \
-        {                                                               \
-            return err;                                                 \
-        }                                                               \
-        err = function(b, c, d);                                        \
-        lfs->cfg->unlock(lfs->cfg);                                     \
-        return err;                                                     \
-    }
-#define CREATE_LFS_TS_4(ret, function, b_type, b, c_type, c, d_type, d, e_type, e) \
-    ret _ts ## function(b_type b, c_type c, d_type d, e_type e)                    \
-    {                                                                              \
-        int err = lfs->cfg->lock(lfs->cfg);                                        \
-        if (err)                                                                   \
-        {                                                                          \
-            return err;                                                            \
-        }                                                                          \
-        err = function(b, c, d, e);                                                \
-        lfs->cfg->unlock(lfs->cfg);                                                \
-        return err;                                                                \
-    }
-#define CREATE_LFS_TS_5(ret, function, b_type, b, c_type, c, d_type, d, e_type, e, f_type, f) \
-    ret _ts ## function(b_type b, c_type c, d_type d, e_type e, f_type f)                     \
-    {                                                                                         \
-        int err = lfs->cfg->lock(lfs->cfg);                                                   \
-        if (err)                                                                              \
-        {                                                                                     \
-            return err;                                                                       \
-        }                                                                                     \
-        err = function(b, c, d, e, f);                                                        \
-        lfs->cfg->unlock(lfs->cfg);                                                           \
-        return err;                                                                           \
-    }
-
-int _ts_lfs_fs_traverse (lfs_t * lfs, int (* cb)(void * data, lfs_block_t block), void * data) {
-    int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
+int _ts_lfs_format(lfs_t *lfs, const struct lfs_config *config)
+{
+    int err = config->lock(lfs->cfg);
+    if(err)
     {
         return err;
     }
+    err = lfs_format(lfs, config);
+    config->unlock(lfs->cfg);
 
-    err = _lfs_fs_traverse(lfs, cb, data);
+    return err;
+}
+int _ts_lfs_mount(lfs_t *lfs, const struct lfs_config *config)
+{
+    int err = config->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_mount(lfs, config);
+    config->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_unmount(lfs_t *lfs)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_unmount(lfs);
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
+int _ts_lfs_remove(lfs_t *lfs, const char *path)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_remove(lfs, path);
+    lfs->cfg->unlock(lfs->cfg);
 
-CREATE_LFS_TS_2_CFG(int, _lfs_format,lfs_t *, lfs, const struct lfs_config *, config)
-CREATE_LFS_TS_2_CFG(int, _lfs_mount,lfs_t *, lfs, const struct lfs_config *, config)
-CREATE_LFS_TS_1(int, _lfs_unmount,lfs_t *, lfs)
-CREATE_LFS_TS_2(int, _lfs_remove,lfs_t *, lfs, const char *, path)
-CREATE_LFS_TS_3(int, _lfs_rename, lfs_t *, lfs, const char *, oldpath, const char *, newpath)
-CREATE_LFS_TS_3(int, _lfs_stat, lfs_t *, lfs, const char *, path, struct lfs_info *, info)
-CREATE_LFS_TS_5(lfs_ssize_t, _lfs_getattr, lfs_t *, lfs, const char *, path, uint8_t, type, void *, buffer, lfs_size_t, size)
-CREATE_LFS_TS_5(int, _lfs_setattr, lfs_t *, lfs, const char *, path, uint8_t, type, const void *, buffer, lfs_size_t, size)
-CREATE_LFS_TS_3(int, _lfs_removeattr, lfs_t *, lfs, const char *, path, uint8_t, type)
-CREATE_LFS_TS_4(int, _lfs_file_open, lfs_t *, lfs, lfs_file_t *, file, const char *, path, int, flags)
-CREATE_LFS_TS_5(int, _lfs_file_opencfg, lfs_t *, lfs, lfs_file_t *, file, const char *, path, int, flags, const struct lfs_file_config *, config)
-CREATE_LFS_TS_2(int, _lfs_file_close, lfs_t *, lfs, lfs_file_t *, file)
-CREATE_LFS_TS_2(int, _lfs_file_sync, lfs_t *, lfs, lfs_file_t *, file)
-CREATE_LFS_TS_4(lfs_ssize_t, _lfs_file_read, lfs_t *, lfs, lfs_file_t *, file, void *, buffer, lfs_size_t, size)
-CREATE_LFS_TS_4(lfs_ssize_t, _lfs_file_write, lfs_t *, lfs, lfs_file_t *, file, const void *, buffer, lfs_size_t, size)
-CREATE_LFS_TS_4(lfs_soff_t, _lfs_file_seek, lfs_t *, lfs, lfs_file_t *, file, lfs_soff_t, off, int, whence)
-CREATE_LFS_TS_3(int, _lfs_file_truncate, lfs_t *, lfs, lfs_file_t *, file, lfs_off_t, size)
-CREATE_LFS_TS_2(lfs_soff_t, _lfs_file_tell, lfs_t *, lfs, lfs_file_t *, file)
-CREATE_LFS_TS_2(int, _lfs_file_rewind, lfs_t *, lfs, lfs_file_t *, file)
-CREATE_LFS_TS_2(lfs_soff_t, _lfs_file_size, lfs_t *, lfs, lfs_file_t *, file)
-CREATE_LFS_TS_2(int, _lfs_mkdir, lfs_t *, lfs, const char *, path)
-CREATE_LFS_TS_3(int, _lfs_dir_open, lfs_t *, lfs, lfs_dir_t *, dir, const char *, path)
-CREATE_LFS_TS_2(int, _lfs_dir_close, lfs_t *, lfs, lfs_dir_t *, dir)
-CREATE_LFS_TS_3(int, _lfs_dir_read, lfs_t *, lfs, lfs_dir_t *, dir, struct lfs_info *, info)
-CREATE_LFS_TS_3(int, _lfs_dir_seek, lfs_t *, lfs, lfs_dir_t *, dir, lfs_off_t, off)
-CREATE_LFS_TS_2(lfs_soff_t, _lfs_dir_tell, lfs_t *, lfs, lfs_dir_t *, dir)
-CREATE_LFS_TS_2(int, _lfs_dir_rewind, lfs_t *, lfs, lfs_dir_t *, dir)
-CREATE_LFS_TS_1(lfs_ssize_t, _lfs_fs_size, lfs_t *, lfs)
-#ifdef LFS_MIGRATE
-CREATE_LFS_TS_2_CFG(int, _lfs_migrate, lfs_t *, lfs, const struct lfs_config *, cfg)
-#endif
+    return err;
+}
+int _ts_lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_rename(lfs, oldpath, newpath);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_stat(lfs, path, info);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+lfs_ssize_t _ts_lfs_getattr(lfs_t *lfs, const char *path, uint8_t type, void *buffer, lfs_size_t size)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_getattr(lfs, path, type, buffer, size);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_setattr(lfs_t *lfs, const char *path, uint8_t type, const void *buffer, lfs_size_t size)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_setattr(lfs, path, type, buffer, size);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_removeattr(lfs, path, type);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_file_open(lfs_t *lfs, lfs_file_t *file, const char *path, int flags)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_file_open(lfs, file, path, flags);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, const struct lfs_file_config *config)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_file_opencfg(lfs, file, path, flags, config);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_file_close(lfs_t *lfs, lfs_file_t *file)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_file_close(lfs, file);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_file_sync(lfs_t *lfs, lfs_file_t *file)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_file_sync(lfs, file);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+lfs_ssize_t _ts_lfs_file_read(lfs_t *lfs, lfs_file_t *file, void *buffer, lfs_size_t size)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_file_read(lfs, file, buffer, size);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+lfs_ssize_t _ts_lfs_file_write(lfs_t *lfs, lfs_file_t *file, const void *buffer, lfs_size_t size)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_file_write(lfs, file, buffer, size);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+lfs_soff_t _ts_lfs_file_seek(lfs_t *lfs, lfs_file_t *file, lfs_soff_t off, int whence)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_file_seek(lfs, file, off, whence);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_file_truncate(lfs, file, size);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+lfs_soff_t _ts_lfs_file_tell(lfs_t *lfs, lfs_file_t *file)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_file_tell(lfs, file);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_file_rewind(lfs_t *lfs, lfs_file_t *file)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_file_rewind(lfs, file);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+lfs_soff_t _ts_lfs_file_size(lfs_t *lfs, lfs_file_t *file)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_file_size(lfs, file);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_mkdir(lfs_t *lfs, const char *path)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_mkdir(lfs, path);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_dir_open(lfs, dir, path);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_dir_close(lfs, dir);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_dir_read(lfs, dir, info);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_dir_seek(lfs, dir, off);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+lfs_soff_t _ts_lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_dir_tell(lfs, dir);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_dir_rewind(lfs, dir);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+lfs_ssize_t _ts_lfs_fs_size(lfs_t *lfs)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_fs_size(lfs);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_fs_traverse(lfs, cb, data);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
+int _ts_lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg)
+{
+    int err = lfs->cfg->lock(lfs->cfg);
+    if(err)
+    {
+        return err;
+    }
+    err = lfs_migrate(lfs, cfg);
+    
+    lfs->cfg->unlock(lfs->cfg);
+
+    return err;
+}
 #endif

--- a/lfs.c
+++ b/lfs.c
@@ -4916,25 +4916,25 @@ cleanup:
 
 int lfs_format_ts(lfs_t *lfs, const struct lfs_config *config)
 {
-    int err = config->lock(lfs->cfg);
+    int err = config->lock(config);
     if(err)
     {
         return err;
     }
     err = lfs_format_raw(lfs, config);
-    config->unlock(lfs->cfg);
+    config->unlock(config);
 
     return err;
 }
 int lfs_mount_ts(lfs_t *lfs, const struct lfs_config *config)
 {
-    int err = config->lock(lfs->cfg);
+    int err = config->lock(config);
     if(err)
     {
         return err;
     }
     err = lfs_mount_raw(lfs, config);
-    config->unlock(lfs->cfg);
+    config->unlock(config);
 
     return err;
 }

--- a/lfs.c
+++ b/lfs.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "lfs.h"
-#include "lfs_util.h"
+#include <lfs_util.h>
 
 #define LFS_BLOCK_NULL ((lfs_block_t)-1)
 #define LFS_BLOCK_INLINE ((lfs_block_t)-2)

--- a/lfs.c
+++ b/lfs.c
@@ -4916,8 +4916,7 @@ cleanup:
 
 int lfs_format (lfs_t * lfs, const struct lfs_config * config) {
     int err = config->lock(config);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -4929,8 +4928,7 @@ int lfs_format (lfs_t * lfs, const struct lfs_config * config) {
 
 int lfs_mount (lfs_t * lfs, const struct lfs_config * config) {
     int err = config->lock(config);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -4942,8 +4940,7 @@ int lfs_mount (lfs_t * lfs, const struct lfs_config * config) {
 
 int lfs_unmount (lfs_t * lfs) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -4955,8 +4952,7 @@ int lfs_unmount (lfs_t * lfs) {
 
 int lfs_remove (lfs_t * lfs, const char * path) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -4968,8 +4964,7 @@ int lfs_remove (lfs_t * lfs, const char * path) {
 
 int lfs_rename (lfs_t * lfs, const char * oldpath, const char * newpath) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -4982,8 +4977,7 @@ int lfs_rename (lfs_t * lfs, const char * oldpath, const char * newpath) {
 
 int lfs_stat (lfs_t * lfs, const char * path, struct lfs_info * info) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -4996,8 +4990,7 @@ int lfs_stat (lfs_t * lfs, const char * path, struct lfs_info * info) {
 
 lfs_ssize_t lfs_getattr (lfs_t * lfs, const char * path, uint8_t type, void * buffer, lfs_size_t size) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5010,8 +5003,7 @@ lfs_ssize_t lfs_getattr (lfs_t * lfs, const char * path, uint8_t type, void * bu
 
 int lfs_setattr (lfs_t * lfs, const char * path, uint8_t type, const void * buffer, lfs_size_t size) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5024,8 +5016,7 @@ int lfs_setattr (lfs_t * lfs, const char * path, uint8_t type, const void * buff
 
 int lfs_removeattr (lfs_t * lfs, const char * path, uint8_t type) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5038,8 +5029,7 @@ int lfs_removeattr (lfs_t * lfs, const char * path, uint8_t type) {
 
 int lfs_file_open (lfs_t * lfs, lfs_file_t * file, const char * path, int flags) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5052,8 +5042,7 @@ int lfs_file_open (lfs_t * lfs, lfs_file_t * file, const char * path, int flags)
 
 int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, const struct lfs_file_config *config) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5066,8 +5055,7 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, 
 
 int lfs_file_close (lfs_t * lfs, lfs_file_t * file) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5080,8 +5068,7 @@ int lfs_file_close (lfs_t * lfs, lfs_file_t * file) {
 
 int lfs_file_sync (lfs_t * lfs, lfs_file_t * file) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5094,8 +5081,7 @@ int lfs_file_sync (lfs_t * lfs, lfs_file_t * file) {
 
 lfs_ssize_t lfs_file_read (lfs_t * lfs, lfs_file_t * file, void * buffer, lfs_size_t size) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5108,8 +5094,7 @@ lfs_ssize_t lfs_file_read (lfs_t * lfs, lfs_file_t * file, void * buffer, lfs_si
 
 lfs_ssize_t lfs_file_write (lfs_t * lfs, lfs_file_t * file, const void * buffer, lfs_size_t size) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5122,8 +5107,7 @@ lfs_ssize_t lfs_file_write (lfs_t * lfs, lfs_file_t * file, const void * buffer,
 
 lfs_soff_t lfs_file_seek (lfs_t * lfs, lfs_file_t * file, lfs_soff_t off, int whence) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5136,8 +5120,7 @@ lfs_soff_t lfs_file_seek (lfs_t * lfs, lfs_file_t * file, lfs_soff_t off, int wh
 
 int lfs_file_truncate (lfs_t * lfs, lfs_file_t * file, lfs_off_t size) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5150,8 +5133,7 @@ int lfs_file_truncate (lfs_t * lfs, lfs_file_t * file, lfs_off_t size) {
 
 lfs_soff_t lfs_file_tell (lfs_t * lfs, lfs_file_t * file) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5164,8 +5146,7 @@ lfs_soff_t lfs_file_tell (lfs_t * lfs, lfs_file_t * file) {
 
 int lfs_file_rewind (lfs_t * lfs, lfs_file_t * file) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5178,8 +5159,7 @@ int lfs_file_rewind (lfs_t * lfs, lfs_file_t * file) {
 
 lfs_soff_t lfs_file_size (lfs_t * lfs, lfs_file_t * file) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5192,8 +5172,7 @@ lfs_soff_t lfs_file_size (lfs_t * lfs, lfs_file_t * file) {
 
 int lfs_mkdir (lfs_t * lfs, const char * path) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5206,8 +5185,7 @@ int lfs_mkdir (lfs_t * lfs, const char * path) {
 
 int lfs_dir_open (lfs_t * lfs, lfs_dir_t * dir, const char * path) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5220,8 +5198,7 @@ int lfs_dir_open (lfs_t * lfs, lfs_dir_t * dir, const char * path) {
 
 int lfs_dir_close (lfs_t * lfs, lfs_dir_t * dir) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5234,8 +5211,7 @@ int lfs_dir_close (lfs_t * lfs, lfs_dir_t * dir) {
 
 int lfs_dir_read (lfs_t * lfs, lfs_dir_t * dir, struct lfs_info * info) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5248,8 +5224,7 @@ int lfs_dir_read (lfs_t * lfs, lfs_dir_t * dir, struct lfs_info * info) {
 
 int lfs_dir_seek (lfs_t * lfs, lfs_dir_t * dir, lfs_off_t off) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5262,8 +5237,7 @@ int lfs_dir_seek (lfs_t * lfs, lfs_dir_t * dir, lfs_off_t off) {
 
 lfs_soff_t lfs_dir_tell (lfs_t * lfs, lfs_dir_t * dir) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5276,8 +5250,7 @@ lfs_soff_t lfs_dir_tell (lfs_t * lfs, lfs_dir_t * dir) {
 
 int lfs_dir_rewind (lfs_t * lfs, lfs_dir_t * dir) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5290,8 +5263,7 @@ int lfs_dir_rewind (lfs_t * lfs, lfs_dir_t * dir) {
 
 lfs_ssize_t lfs_fs_size (lfs_t * lfs) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5304,8 +5276,7 @@ lfs_ssize_t lfs_fs_size (lfs_t * lfs) {
 
 int lfs_fs_traverse (lfs_t * lfs, int (* cb)(void *, lfs_block_t), void * data) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 
@@ -5320,8 +5291,7 @@ int lfs_fs_traverse (lfs_t * lfs, int (* cb)(void *, lfs_block_t), void * data) 
 
 int lfs_migrate (lfs_t * lfs, const struct lfs_config * cfg) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if (err)
-    {
+    if (err) {
         return err;
     }
 

--- a/lfs.c
+++ b/lfs.c
@@ -5287,6 +5287,9 @@ int lfs_fs_traverse_ts(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data)
 
     return err;
 }
+
+#ifdef LFS_MIGRATE
+
 int lfs_migrate_ts(lfs_t *lfs, const struct lfs_config *cfg)
 {
     int err = lfs->cfg->lock(lfs->cfg);
@@ -5300,4 +5303,6 @@ int lfs_migrate_ts(lfs_t *lfs, const struct lfs_config *cfg)
 
     return err;
 }
+
+#endif
 #endif

--- a/lfs.c
+++ b/lfs.c
@@ -10,6 +10,37 @@
 #define LFS_BLOCK_NULL ((lfs_block_t)-1)
 #define LFS_BLOCK_INLINE ((lfs_block_t)-2)
 
+static int lfs_format_raw(lfs_t *lfs, const struct lfs_config *config);
+static int lfs_mount_raw(lfs_t *lfs, const struct lfs_config *config);
+static int lfs_unmount_raw(lfs_t *lfs);
+static int lfs_remove_raw(lfs_t *lfs, const char *path);
+static int lfs_rename_raw(lfs_t *lfs, const char *oldpath, const char *newpath);
+static int lfs_stat_raw(lfs_t *lfs, const char *path, struct lfs_info *info);
+static lfs_ssize_t lfs_getattr_raw(lfs_t *lfs, const char *path, uint8_t type, void *buffer, lfs_size_t size);
+static int lfs_setattr_raw(lfs_t *lfs, const char *path, uint8_t type, const void *buffer, lfs_size_t size);
+static int lfs_removeattr_raw(lfs_t *lfs, const char *path, uint8_t type);
+static int lfs_file_open_raw(lfs_t *lfs, lfs_file_t *file, const char *path, int flags);
+static int lfs_file_opencfg_raw(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, const struct lfs_file_config *config);
+static int lfs_file_close_raw(lfs_t *lfs, lfs_file_t *file);
+static int lfs_file_sync_raw(lfs_t *lfs, lfs_file_t *file);
+static lfs_ssize_t lfs_file_read_raw(lfs_t *lfs, lfs_file_t *file, void *buffer, lfs_size_t size);
+static lfs_ssize_t lfs_file_write_raw(lfs_t *lfs, lfs_file_t *file, const void *buffer, lfs_size_t size);
+static lfs_soff_t lfs_file_seek_raw(lfs_t *lfs, lfs_file_t *file, lfs_soff_t off, int whence);
+static int lfs_file_truncate_raw(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
+static lfs_soff_t lfs_file_tell_raw(lfs_t *lfs, lfs_file_t *file);
+static int lfs_file_rewind_raw(lfs_t *lfs, lfs_file_t *file);
+static lfs_soff_t lfs_file_size_raw(lfs_t *lfs, lfs_file_t *file);
+static int lfs_mkdir_raw(lfs_t *lfs, const char *path);
+static int lfs_dir_open_raw(lfs_t *lfs, lfs_dir_t *dir, const char *path);
+static int lfs_dir_close_raw(lfs_t *lfs, lfs_dir_t *dir);
+static int lfs_dir_read_raw(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
+static int lfs_dir_seek_raw(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
+static lfs_soff_t lfs_dir_tell_raw(lfs_t *lfs, lfs_dir_t *dir);
+static int lfs_dir_rewind_raw(lfs_t *lfs, lfs_dir_t *dir);
+static lfs_ssize_t lfs_fs_size_raw(lfs_t *lfs);
+static int lfs_fs_traverse_raw(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
+static int lfs_migrate_raw(lfs_t *lfs, const struct lfs_config *cfg);
+
 /// Caching block device operations ///
 static inline void lfs_cache_drop(lfs_t *lfs, lfs_cache_t *rcache) {
     // do not zero, cheaper if cache is readonly or only going to be
@@ -4914,7 +4945,7 @@ cleanup:
 
 #if LFS_THREADSAFE
 
-int lfs_format (lfs_t * lfs, const struct lfs_config * config) {
+int lfs_format(lfs_t *lfs, const struct lfs_config *config) {
     int err = config->lock(config);
     if (err) {
         return err;
@@ -4926,7 +4957,7 @@ int lfs_format (lfs_t * lfs, const struct lfs_config * config) {
     return err;
 }
 
-int lfs_mount (lfs_t * lfs, const struct lfs_config * config) {
+int lfs_mount(lfs_t *lfs, const struct lfs_config *config) {
     int err = config->lock(config);
     if (err) {
         return err;
@@ -4938,7 +4969,7 @@ int lfs_mount (lfs_t * lfs, const struct lfs_config * config) {
     return err;
 }
 
-int lfs_unmount (lfs_t * lfs) {
+int lfs_unmount(lfs_t *lfs) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -4950,7 +4981,7 @@ int lfs_unmount (lfs_t * lfs) {
     return err;
 }
 
-int lfs_remove (lfs_t * lfs, const char * path) {
+int lfs_remove(lfs_t *lfs, const char *path) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -4962,7 +4993,7 @@ int lfs_remove (lfs_t * lfs, const char * path) {
     return err;
 }
 
-int lfs_rename (lfs_t * lfs, const char * oldpath, const char * newpath) {
+int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -4975,7 +5006,7 @@ int lfs_rename (lfs_t * lfs, const char * oldpath, const char * newpath) {
     return err;
 }
 
-int lfs_stat (lfs_t * lfs, const char * path, struct lfs_info * info) {
+int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -4988,7 +5019,7 @@ int lfs_stat (lfs_t * lfs, const char * path, struct lfs_info * info) {
     return err;
 }
 
-lfs_ssize_t lfs_getattr (lfs_t * lfs, const char * path, uint8_t type, void * buffer, lfs_size_t size) {
+lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path, uint8_t type, void *buffer, lfs_size_t size) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5001,7 +5032,7 @@ lfs_ssize_t lfs_getattr (lfs_t * lfs, const char * path, uint8_t type, void * bu
     return err;
 }
 
-int lfs_setattr (lfs_t * lfs, const char * path, uint8_t type, const void * buffer, lfs_size_t size) {
+int lfs_setattr(lfs_t *lfs, const char *path, uint8_t type, const void *buffer, lfs_size_t size) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5014,7 +5045,7 @@ int lfs_setattr (lfs_t * lfs, const char * path, uint8_t type, const void * buff
     return err;
 }
 
-int lfs_removeattr (lfs_t * lfs, const char * path, uint8_t type) {
+int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5027,7 +5058,7 @@ int lfs_removeattr (lfs_t * lfs, const char * path, uint8_t type) {
     return err;
 }
 
-int lfs_file_open (lfs_t * lfs, lfs_file_t * file, const char * path, int flags) {
+int lfs_file_open(lfs_t *lfs, lfs_file_t *file, const char *path, int flags) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5053,7 +5084,7 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, 
     return err;
 }
 
-int lfs_file_close (lfs_t * lfs, lfs_file_t * file) {
+int lfs_file_close(lfs_t *lfs, lfs_file_t *file) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5066,7 +5097,7 @@ int lfs_file_close (lfs_t * lfs, lfs_file_t * file) {
     return err;
 }
 
-int lfs_file_sync (lfs_t * lfs, lfs_file_t * file) {
+int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5079,7 +5110,7 @@ int lfs_file_sync (lfs_t * lfs, lfs_file_t * file) {
     return err;
 }
 
-lfs_ssize_t lfs_file_read (lfs_t * lfs, lfs_file_t * file, void * buffer, lfs_size_t size) {
+lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file, void *buffer, lfs_size_t size) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5092,7 +5123,7 @@ lfs_ssize_t lfs_file_read (lfs_t * lfs, lfs_file_t * file, void * buffer, lfs_si
     return err;
 }
 
-lfs_ssize_t lfs_file_write (lfs_t * lfs, lfs_file_t * file, const void * buffer, lfs_size_t size) {
+lfs_ssize_t lfs_file_write(lfs_t *lfs, lfs_file_t *file, const void *buffer, lfs_size_t size) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5105,7 +5136,7 @@ lfs_ssize_t lfs_file_write (lfs_t * lfs, lfs_file_t * file, const void * buffer,
     return err;
 }
 
-lfs_soff_t lfs_file_seek (lfs_t * lfs, lfs_file_t * file, lfs_soff_t off, int whence) {
+lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file, lfs_soff_t off, int whence) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5118,7 +5149,7 @@ lfs_soff_t lfs_file_seek (lfs_t * lfs, lfs_file_t * file, lfs_soff_t off, int wh
     return err;
 }
 
-int lfs_file_truncate (lfs_t * lfs, lfs_file_t * file, lfs_off_t size) {
+int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5131,7 +5162,7 @@ int lfs_file_truncate (lfs_t * lfs, lfs_file_t * file, lfs_off_t size) {
     return err;
 }
 
-lfs_soff_t lfs_file_tell (lfs_t * lfs, lfs_file_t * file) {
+lfs_soff_t lfs_file_tell(lfs_t *lfs, lfs_file_t *file) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5144,7 +5175,7 @@ lfs_soff_t lfs_file_tell (lfs_t * lfs, lfs_file_t * file) {
     return err;
 }
 
-int lfs_file_rewind (lfs_t * lfs, lfs_file_t * file) {
+int lfs_file_rewind(lfs_t *lfs, lfs_file_t *file) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5157,7 +5188,7 @@ int lfs_file_rewind (lfs_t * lfs, lfs_file_t * file) {
     return err;
 }
 
-lfs_soff_t lfs_file_size (lfs_t * lfs, lfs_file_t * file) {
+lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5170,7 +5201,7 @@ lfs_soff_t lfs_file_size (lfs_t * lfs, lfs_file_t * file) {
     return err;
 }
 
-int lfs_mkdir (lfs_t * lfs, const char * path) {
+int lfs_mkdir(lfs_t *lfs, const char *path) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5183,7 +5214,7 @@ int lfs_mkdir (lfs_t * lfs, const char * path) {
     return err;
 }
 
-int lfs_dir_open (lfs_t * lfs, lfs_dir_t * dir, const char * path) {
+int lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5196,7 +5227,7 @@ int lfs_dir_open (lfs_t * lfs, lfs_dir_t * dir, const char * path) {
     return err;
 }
 
-int lfs_dir_close (lfs_t * lfs, lfs_dir_t * dir) {
+int lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5209,7 +5240,7 @@ int lfs_dir_close (lfs_t * lfs, lfs_dir_t * dir) {
     return err;
 }
 
-int lfs_dir_read (lfs_t * lfs, lfs_dir_t * dir, struct lfs_info * info) {
+int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5222,7 +5253,7 @@ int lfs_dir_read (lfs_t * lfs, lfs_dir_t * dir, struct lfs_info * info) {
     return err;
 }
 
-int lfs_dir_seek (lfs_t * lfs, lfs_dir_t * dir, lfs_off_t off) {
+int lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5235,7 +5266,7 @@ int lfs_dir_seek (lfs_t * lfs, lfs_dir_t * dir, lfs_off_t off) {
     return err;
 }
 
-lfs_soff_t lfs_dir_tell (lfs_t * lfs, lfs_dir_t * dir) {
+lfs_soff_t lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5248,7 +5279,7 @@ lfs_soff_t lfs_dir_tell (lfs_t * lfs, lfs_dir_t * dir) {
     return err;
 }
 
-int lfs_dir_rewind (lfs_t * lfs, lfs_dir_t * dir) {
+int lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5261,7 +5292,7 @@ int lfs_dir_rewind (lfs_t * lfs, lfs_dir_t * dir) {
     return err;
 }
 
-lfs_ssize_t lfs_fs_size (lfs_t * lfs) {
+lfs_ssize_t lfs_fs_size(lfs_t *lfs) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5274,7 +5305,7 @@ lfs_ssize_t lfs_fs_size (lfs_t * lfs) {
     return err;
 }
 
-int lfs_fs_traverse (lfs_t * lfs, int (* cb)(void *, lfs_block_t), void * data) {
+int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void *, lfs_block_t), void *data) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5289,7 +5320,7 @@ int lfs_fs_traverse (lfs_t * lfs, int (* cb)(void *, lfs_block_t), void * data) 
 
 #ifdef LFS_MIGRATE
 
-int lfs_migrate (lfs_t * lfs, const struct lfs_config * cfg) {
+int lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err) {
         return err;
@@ -5305,125 +5336,125 @@ int lfs_migrate (lfs_t * lfs, const struct lfs_config * cfg) {
 #endif
 #else
 
-int lfs_format (lfs_t * lfs, const struct lfs_config * config) {
+int lfs_format(lfs_t *lfs, const struct lfs_config *config) {
     return lfs_format_raw(lfs, config);
 }
 
-int lfs_mount (lfs_t * lfs, const struct lfs_config * config) {
+int lfs_mount(lfs_t *lfs, const struct lfs_config *config) {
     return lfs_mount_raw(lfs, config);
 }
 
-int lfs_unmount (lfs_t * lfs) {
+int lfs_unmount(lfs_t *lfs) {
     return lfs_unmount_raw(lfs);
 }
 
-int lfs_remove (lfs_t * lfs, const char * path) {
+int lfs_remove(lfs_t *lfs, const char *path) {
     return lfs_remove_raw(lfs, path);
 }
 
-int lfs_rename (lfs_t * lfs, const char * oldpath, const char * newpath) {
+int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
     return lfs_rename_raw(lfs, oldpath, newpath);
 }
 
-int lfs_stat (lfs_t * lfs, const char * path, struct lfs_info * info) {
+int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info) {
     return lfs_stat_raw(lfs, path, info);
 }
 
-lfs_ssize_t lfs_getattr (lfs_t * lfs, const char * path, uint8_t type, void * buffer, lfs_size_t size) {
+lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path, uint8_t type, void *buffer, lfs_size_t size) {
     return lfs_getattr_raw(lfs, path, type, buffer, size);
 }
 
-int lfs_setattr (lfs_t * lfs, const char * path, uint8_t type, const void * buffer, lfs_size_t size) {
+int lfs_setattr(lfs_t *lfs, const char *path, uint8_t type, const void *buffer, lfs_size_t size) {
     return lfs_setattr_raw(lfs, path, type, buffer, size);
 }
 
-int lfs_removeattr (lfs_t * lfs, const char * path, uint8_t type) {
+int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type) {
     return lfs_removeattr_raw(lfs, path, type);
 }
 
-int lfs_file_open (lfs_t * lfs, lfs_file_t * file, const char * path, int flags) {
+int lfs_file_open(lfs_t *lfs, lfs_file_t *file, const char *path, int flags) {
     return lfs_file_open_raw(lfs, file, path, flags);
 }
 
-int lfs_file_opencfg_ts(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, const struct lfs_file_config *config) {
+int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, const struct lfs_file_config *config) {
     return lfs_file_opencfg_raw(lfs, file, path, flags, config);
 }
 
-int lfs_file_close (lfs_t * lfs, lfs_file_t * file) {
+int lfs_file_close(lfs_t *lfs, lfs_file_t *file) {
     return lfs_file_close_raw(lfs, file);
 }
 
-int lfs_file_sync (lfs_t * lfs, lfs_file_t * file) {
+int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
     return lfs_file_sync_raw(lfs, file);
 }
 
-lfs_ssize_t lfs_file_read (lfs_t * lfs, lfs_file_t * file, void * buffer, lfs_size_t size) {
+lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file, void *buffer, lfs_size_t size) {
     return lfs_file_read_raw(lfs, file, buffer, size);
 }
 
-lfs_ssize_t lfs_file_write (lfs_t * lfs, lfs_file_t * file, const void * buffer, lfs_size_t size) {
+lfs_ssize_t lfs_file_write(lfs_t *lfs, lfs_file_t *file, const void *buffer, lfs_size_t size) {
     return lfs_file_write_raw(lfs, file, buffer, size);
 }
 
-lfs_soff_t lfs_file_seek (lfs_t * lfs, lfs_file_t * file, lfs_soff_t off, int whence) {
+lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file, lfs_soff_t off, int whence) {
     return lfs_file_seek_raw(lfs, file, off, whence);
 }
 
-int lfs_file_truncate (lfs_t * lfs, lfs_file_t * file, lfs_off_t size) {
+int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     return lfs_file_truncate_raw(lfs, file, size);
 }
 
-lfs_soff_t lfs_file_tell (lfs_t * lfs, lfs_file_t * file) {
+lfs_soff_t lfs_file_tell(lfs_t *lfs, lfs_file_t *file) {
     return lfs_file_tell_raw(lfs, file);
 }
 
-int lfs_file_rewind (lfs_t * lfs, lfs_file_t * file) {
+int lfs_file_rewind(lfs_t *lfs, lfs_file_t *file) {
     return lfs_file_rewind_raw(lfs, file);
 }
 
-lfs_soff_t lfs_file_size (lfs_t * lfs, lfs_file_t * file) {
+lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file) {
     return lfs_file_size_raw(lfs, file);
 }
 
-int lfs_mkdir (lfs_t * lfs, const char * path) {
+int lfs_mkdir(lfs_t *lfs, const char *path) {
     return lfs_mkdir_raw(lfs, path);
 }
 
-int lfs_dir_open (lfs_t * lfs, lfs_dir_t * dir, const char * path) {
+int lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
     return lfs_dir_open_raw(lfs, dir, path);
 }
 
-int lfs_dir_close (lfs_t * lfs, lfs_dir_t * dir) {
+int lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir) {
     return lfs_dir_close_raw(lfs, dir);
 }
 
-int lfs_dir_read (lfs_t * lfs, lfs_dir_t * dir, struct lfs_info * info) {
+int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
     return lfs_dir_read_raw(lfs, dir, info);
 }
 
-int lfs_dir_seek (lfs_t * lfs, lfs_dir_t * dir, lfs_off_t off) {
+int lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
     return lfs_dir_seek_raw(lfs, dir, off);
 }
 
-lfs_soff_t lfs_dir_tell (lfs_t * lfs, lfs_dir_t * dir) {
+lfs_soff_t lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir) {
     return lfs_dir_tell_raw(lfs, dir);
 }
 
-int lfs_dir_rewind (lfs_t * lfs, lfs_dir_t * dir) {
+int lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir) {
     return lfs_dir_rewind_raw(lfs, dir);
 }
 
-lfs_ssize_t lfs_fs_size (lfs_t * lfs) {
+lfs_ssize_t lfs_fs_size(lfs_t *lfs) {
     return lfs_fs_size_raw(lfs);
 }
 
-int lfs_fs_traverse (lfs_t * lfs, int (* cb)(void *, lfs_block_t), void * data) {
+int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void *, lfs_block_t), void *data) {
     return lfs_fs_traverse_raw(lfs, cb, data);
 }
 
 #ifdef LFS_MIGRATE
 
-int lfs_migrate (lfs_t * lfs, const struct lfs_config * cfg) {
+int lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg) {
     return lfs_migrate_raw(lfs, cfg);
 }
 

--- a/lfs.c
+++ b/lfs.c
@@ -4912,377 +4912,541 @@ cleanup:
 
 #endif
 
-#if LFS_THREAD_SAFE
+#if !LFS_THREADSAFE
 
-int lfs_format_ts(lfs_t *lfs, const struct lfs_config *config)
-{
+int lfs_format (lfs_t * lfs, const struct lfs_config * config) {
+    return lfs_format_raw(lfs, config);
+}
+
+int lfs_mount (lfs_t * lfs, const struct lfs_config * config) {
+    return lfs_mount_raw(lfs, config);
+}
+
+int lfs_unmount (lfs_t * lfs) {
+    return lfs_unmount_raw(lfs);
+}
+
+int lfs_remove (lfs_t * lfs, const char * path) {
+    return lfs_remove_raw(lfs, path);
+}
+
+int lfs_rename (lfs_t * lfs, const char * oldpath, const char * newpath) {
+    return lfs_rename_raw(lfs, oldpath, newpath);
+}
+
+int lfs_stat (lfs_t * lfs, const char * path, struct lfs_info * info) {
+    return lfs_stat_raw(lfs, path, info);
+}
+
+lfs_ssize_t lfs_getattr (lfs_t * lfs, const char * path, uint8_t type, void * buffer, lfs_size_t size) {
+    return lfs_getattr_raw(lfs, path, type, buffer, size);
+}
+
+int lfs_setattr (lfs_t * lfs, const char * path, uint8_t type, const void * buffer, lfs_size_t size) {
+    return lfs_setattr_raw(lfs, path, type, buffer, size);
+}
+
+int lfs_removeattr (lfs_t * lfs, const char * path, uint8_t type) {
+    return lfs_removeattr_raw(lfs, path, type);
+}
+
+int lfs_file_open (lfs_t * lfs, lfs_file_t * file, const char * path, int flags) {
+    return lfs_file_open_raw(lfs, file, path, flags);
+}
+
+int lfs_file_opencfg (lfs_t                        * lfs,
+                         lfs_file_t                   * file,
+                         const char                   * path,
+                         int                            flags,
+                         const struct lfs_file_config * config) {
+    return lfs_file_opencfg_raw(lfs, file, path, flags, config);
+}
+
+int lfs_file_close (lfs_t * lfs, lfs_file_t * file) {
+    return lfs_file_close_raw(lfs, file);
+}
+
+int lfs_file_sync (lfs_t * lfs, lfs_file_t * file) {
+    return lfs_file_sync_raw(lfs, file);
+}
+
+lfs_ssize_t lfs_file_read (lfs_t * lfs, lfs_file_t * file, void * buffer, lfs_size_t size) {
+    return lfs_file_read_raw(lfs, file, buffer, size);
+}
+
+lfs_ssize_t lfs_file_write (lfs_t * lfs, lfs_file_t * file, const void * buffer, lfs_size_t size) {
+    return lfs_file_write_raw(lfs, file, buffer, size);
+}
+
+lfs_soff_t lfs_file_seek (lfs_t * lfs, lfs_file_t * file, lfs_soff_t off, int whence) {
+    return lfs_file_seek_raw(lfs, file, off, whence);
+}
+
+int lfs_file_truncate (lfs_t * lfs, lfs_file_t * file, lfs_off_t size) {
+    return lfs_file_truncate_raw(lfs, file, size);
+}
+
+lfs_soff_t lfs_file_tell (lfs_t * lfs, lfs_file_t * file) {
+    return lfs_file_tell_raw(lfs, file);
+}
+
+int lfs_file_rewind (lfs_t * lfs, lfs_file_t * file) {
+    return lfs_file_rewind_raw(lfs, file);
+}
+
+lfs_soff_t lfs_file_size (lfs_t * lfs, lfs_file_t * file) {
+    return lfs_file_size_raw(lfs, file);
+}
+
+int lfs_mkdir (lfs_t * lfs, const char * path) {
+    return lfs_mkdir_raw(lfs, path);
+}
+
+int lfs_dir_open (lfs_t * lfs, lfs_dir_t * dir, const char * path) {
+    return lfs_dir_open_raw(lfs, dir, path);
+}
+
+int lfs_dir_close (lfs_t * lfs, lfs_dir_t * dir) {
+    return lfs_dir_close_raw(lfs, dir);
+}
+
+int lfs_dir_read (lfs_t * lfs, lfs_dir_t * dir, struct lfs_info * info) {
+    return lfs_dir_read_raw(lfs, dir, info);
+}
+
+int lfs_dir_seek (lfs_t * lfs, lfs_dir_t * dir, lfs_off_t off) {
+    return lfs_dir_seek_raw(lfs, dir, off);
+}
+
+lfs_soff_t lfs_dir_tell (lfs_t * lfs, lfs_dir_t * dir) {
+    return lfs_dir_tell_raw(lfs, dir);
+}
+
+int lfs_dir_rewind (lfs_t * lfs, lfs_dir_t * dir) {
+    return lfs_dir_rewind_raw(lfs, dir);
+}
+
+lfs_ssize_t lfs_fs_size (lfs_t * lfs) {
+    return lfs_fs_size_raw(lfs);
+}
+
+int lfs_fs_traverse (lfs_t * lfs, int (* cb)(void *, lfs_block_t), void * data) {
+    return lfs_fs_traverse_raw(lfs, cb, data);
+}
+
+#ifdef LFS_MIGRATE
+
+int lfs_migrate (lfs_t * lfs, const struct lfs_config * cfg) {
+    return lfs_migrate_raw(lfs, cfg);
+}
+
+#endif
+
+#endif
+
+#if LFS_THREADSAFE
+
+int lfs_format (lfs_t * lfs, const struct lfs_config * config) {
     int err = config->lock(config);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_format_raw(lfs, config);
     config->unlock(config);
 
     return err;
 }
-int lfs_mount_ts(lfs_t *lfs, const struct lfs_config *config)
-{
+
+int lfs_mount (lfs_t * lfs, const struct lfs_config * config) {
     int err = config->lock(config);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_mount_raw(lfs, config);
     config->unlock(config);
 
     return err;
 }
-int lfs_unmount_ts(lfs_t *lfs)
-{
+
+int lfs_unmount (lfs_t * lfs) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_unmount_raw(lfs);
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_remove_ts(lfs_t *lfs, const char *path)
-{
+
+int lfs_remove (lfs_t * lfs, const char * path) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_remove_raw(lfs, path);
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_rename_ts(lfs_t *lfs, const char *oldpath, const char *newpath)
-{
+
+int lfs_rename (lfs_t * lfs, const char * oldpath, const char * newpath) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_rename_raw(lfs, oldpath, newpath);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_stat_ts(lfs_t *lfs, const char *path, struct lfs_info *info)
-{
+
+int lfs_stat (lfs_t * lfs, const char * path, struct lfs_info * info) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_stat_raw(lfs, path, info);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_ssize_t lfs_getattr_ts(lfs_t *lfs, const char *path, uint8_t type, void *buffer, lfs_size_t size)
-{
+
+lfs_ssize_t lfs_getattr (lfs_t * lfs, const char * path, uint8_t type, void * buffer, lfs_size_t size) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_getattr_raw(lfs, path, type, buffer, size);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_setattr_ts(lfs_t *lfs, const char *path, uint8_t type, const void *buffer, lfs_size_t size)
-{
+
+int lfs_setattr (lfs_t * lfs, const char * path, uint8_t type, const void * buffer, lfs_size_t size) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_setattr_raw(lfs, path, type, buffer, size);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_removeattr_ts(lfs_t *lfs, const char *path, uint8_t type)
-{
+
+int lfs_removeattr (lfs_t * lfs, const char * path, uint8_t type) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_removeattr_raw(lfs, path, type);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_file_open_ts(lfs_t *lfs, lfs_file_t *file, const char *path, int flags)
-{
+
+int lfs_file_open (lfs_t * lfs, lfs_file_t * file, const char * path, int flags) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_file_open_raw(lfs, file, path, flags);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_file_opencfg_ts(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, const struct lfs_file_config *config)
-{
+
+int lfs_file_opencfg (lfs_t                        * lfs,
+                      lfs_file_t                   * file,
+                      const char                   * path,
+                      int                            flags,
+                      const struct lfs_file_config * config) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_file_opencfg_raw(lfs, file, path, flags, config);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_file_close_ts(lfs_t *lfs, lfs_file_t *file)
-{
+
+int lfs_file_close (lfs_t * lfs, lfs_file_t * file) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_file_close_raw(lfs, file);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_file_sync_ts(lfs_t *lfs, lfs_file_t *file)
-{
+
+int lfs_file_sync (lfs_t * lfs, lfs_file_t * file) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_file_sync_raw(lfs, file);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_ssize_t lfs_file_read_ts(lfs_t *lfs, lfs_file_t *file, void *buffer, lfs_size_t size)
-{
+
+lfs_ssize_t lfs_file_read (lfs_t * lfs, lfs_file_t * file, void * buffer, lfs_size_t size) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_file_read_raw(lfs, file, buffer, size);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_ssize_t lfs_file_write_ts(lfs_t *lfs, lfs_file_t *file, const void *buffer, lfs_size_t size)
-{
+
+lfs_ssize_t lfs_file_write (lfs_t * lfs, lfs_file_t * file, const void * buffer, lfs_size_t size) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_file_write_raw(lfs, file, buffer, size);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_soff_t lfs_file_seek_ts(lfs_t *lfs, lfs_file_t *file, lfs_soff_t off, int whence)
-{
+
+lfs_soff_t lfs_file_seek (lfs_t * lfs, lfs_file_t * file, lfs_soff_t off, int whence) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_file_seek_raw(lfs, file, off, whence);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_file_truncate_ts(lfs_t *lfs, lfs_file_t *file, lfs_off_t size)
-{
+
+int lfs_file_truncate (lfs_t * lfs, lfs_file_t * file, lfs_off_t size) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_file_truncate_raw(lfs, file, size);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_soff_t lfs_file_tell_ts(lfs_t *lfs, lfs_file_t *file)
-{
+
+lfs_soff_t lfs_file_tell (lfs_t * lfs, lfs_file_t * file) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_file_tell_raw(lfs, file);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_file_rewind_ts(lfs_t *lfs, lfs_file_t *file)
-{
+
+int lfs_file_rewind (lfs_t * lfs, lfs_file_t * file) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_file_rewind_raw(lfs, file);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_soff_t lfs_file_size_ts(lfs_t *lfs, lfs_file_t *file)
-{
+
+lfs_soff_t lfs_file_size (lfs_t * lfs, lfs_file_t * file) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_file_size_raw(lfs, file);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_mkdir_ts(lfs_t *lfs, const char *path)
-{
+
+int lfs_mkdir (lfs_t * lfs, const char * path) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_mkdir_raw(lfs, path);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_dir_open_ts(lfs_t *lfs, lfs_dir_t *dir, const char *path)
-{
+
+int lfs_dir_open (lfs_t * lfs, lfs_dir_t * dir, const char * path) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_dir_open_raw(lfs, dir, path);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_dir_close_ts(lfs_t *lfs, lfs_dir_t *dir)
-{
+
+int lfs_dir_close (lfs_t * lfs, lfs_dir_t * dir) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_dir_close_raw(lfs, dir);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_dir_read_ts(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info)
-{
+
+int lfs_dir_read (lfs_t * lfs, lfs_dir_t * dir, struct lfs_info * info) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_dir_read_raw(lfs, dir, info);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_dir_seek_ts(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off)
-{
+
+int lfs_dir_seek (lfs_t * lfs, lfs_dir_t * dir, lfs_off_t off) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_dir_seek_raw(lfs, dir, off);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_soff_t lfs_dir_tell_ts(lfs_t *lfs, lfs_dir_t *dir)
-{
+
+lfs_soff_t lfs_dir_tell (lfs_t * lfs, lfs_dir_t * dir) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_dir_tell_raw(lfs, dir);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_dir_rewind_ts(lfs_t *lfs, lfs_dir_t *dir)
-{
+
+int lfs_dir_rewind (lfs_t * lfs, lfs_dir_t * dir) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_dir_rewind_raw(lfs, dir);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-lfs_ssize_t lfs_fs_size_ts(lfs_t *lfs)
-{
+
+lfs_ssize_t lfs_fs_size (lfs_t * lfs) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_fs_size_raw(lfs);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
 }
-int lfs_fs_traverse_ts(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data)
-{
+
+int lfs_fs_traverse (lfs_t * lfs, int (* cb)(void *, lfs_block_t), void * data) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_fs_traverse_raw(lfs, cb, data);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;
@@ -5290,15 +5454,15 @@ int lfs_fs_traverse_ts(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data)
 
 #ifdef LFS_MIGRATE
 
-int lfs_migrate_ts(lfs_t *lfs, const struct lfs_config *cfg)
-{
+int lfs_migrate (lfs_t * lfs, const struct lfs_config * cfg) {
     int err = lfs->cfg->lock(lfs->cfg);
-    if(err)
+    if (err)
     {
         return err;
     }
+
     err = lfs_migrate_raw(lfs, cfg);
-    
+
     lfs->cfg->unlock(lfs->cfg);
 
     return err;

--- a/lfs.c
+++ b/lfs.c
@@ -5050,11 +5050,7 @@ int lfs_file_open (lfs_t * lfs, lfs_file_t * file, const char * path, int flags)
     return err;
 }
 
-int lfs_file_opencfg (lfs_t                        * lfs,
-                      lfs_file_t                   * file,
-                      const char                   * path,
-                      int                            flags,
-                      const struct lfs_file_config * config) {
+int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, const struct lfs_file_config *config) {
     int err = lfs->cfg->lock(lfs->cfg);
     if (err)
     {
@@ -5379,11 +5375,7 @@ int lfs_file_open (lfs_t * lfs, lfs_file_t * file, const char * path, int flags)
     return lfs_file_open_raw(lfs, file, path, flags);
 }
 
-int lfs_file_opencfg (lfs_t                        * lfs,
-                         lfs_file_t                   * file,
-                         const char                   * path,
-                         int                            flags,
-                         const struct lfs_file_config * config) {
+int lfs_file_opencfg_ts(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, const struct lfs_file_config *config) {
     return lfs_file_opencfg_raw(lfs, file, path, flags, config);
 }
 

--- a/lfs.h
+++ b/lfs.h
@@ -657,37 +657,6 @@ int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 int lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg);
 #endif
 
-int lfs_format_raw(lfs_t *lfs, const struct lfs_config *config);
-int lfs_mount_raw(lfs_t *lfs, const struct lfs_config *config);
-int lfs_unmount_raw(lfs_t *lfs);
-int lfs_remove_raw(lfs_t *lfs, const char *path);
-int lfs_rename_raw(lfs_t *lfs, const char *oldpath, const char *newpath);
-int lfs_stat_raw(lfs_t *lfs, const char *path, struct lfs_info *info);
-lfs_ssize_t lfs_getattr_raw(lfs_t *lfs, const char *path, uint8_t type, void *buffer, lfs_size_t size);
-int lfs_setattr_raw(lfs_t *lfs, const char *path, uint8_t type, const void *buffer, lfs_size_t size);
-int lfs_removeattr_raw(lfs_t *lfs, const char *path, uint8_t type);
-int lfs_file_open_raw(lfs_t *lfs, lfs_file_t *file, const char *path, int flags);
-int lfs_file_opencfg_raw(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, const struct lfs_file_config *config);
-int lfs_file_close_raw(lfs_t *lfs, lfs_file_t *file);
-int lfs_file_sync_raw(lfs_t *lfs, lfs_file_t *file);
-lfs_ssize_t lfs_file_read_raw(lfs_t *lfs, lfs_file_t *file, void *buffer, lfs_size_t size);
-lfs_ssize_t lfs_file_write_raw(lfs_t *lfs, lfs_file_t *file, const void *buffer, lfs_size_t size);
-lfs_soff_t lfs_file_seek_raw(lfs_t *lfs, lfs_file_t *file, lfs_soff_t off, int whence);
-int lfs_file_truncate_raw(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
-lfs_soff_t lfs_file_tell_raw(lfs_t *lfs, lfs_file_t *file);
-int lfs_file_rewind_raw(lfs_t *lfs, lfs_file_t *file);
-lfs_soff_t lfs_file_size_raw(lfs_t *lfs, lfs_file_t *file);
-int lfs_mkdir_raw(lfs_t *lfs, const char *path);
-int lfs_dir_open_raw(lfs_t *lfs, lfs_dir_t *dir, const char *path);
-int lfs_dir_close_raw(lfs_t *lfs, lfs_dir_t *dir);
-int lfs_dir_read_raw(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
-int lfs_dir_seek_raw(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
-lfs_soff_t lfs_dir_tell_raw(lfs_t *lfs, lfs_dir_t *dir);
-int lfs_dir_rewind_raw(lfs_t *lfs, lfs_dir_t *dir);
-lfs_ssize_t lfs_fs_size_raw(lfs_t *lfs);
-int lfs_fs_traverse_raw(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
-int lfs_migrate_raw(lfs_t *lfs, const struct lfs_config *cfg);
-
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/lfs.h
+++ b/lfs.h
@@ -85,9 +85,6 @@ enum lfs_error {
     LFS_ERR_NOMEM       = -12,  // No more memory available
     LFS_ERR_NOATTR      = -61,  // No data/attr available
     LFS_ERR_NAMETOOLONG = -36,  // File name too long
-#if LFS_THREAD_SAFE
-    LFS_ERR_LOCK        = -23,  // Failed to aquire lock
-#endif
 };
 
 // File types

--- a/lfs.h
+++ b/lfs.h
@@ -54,7 +54,7 @@ typedef uint32_t lfs_block_t;
 
 // Maximum size of a file in bytes, may be redefined to limit to support other
 // drivers. Limited on disk to <= 4294967296. However, above 2147483647 the
-// functions _lfs_file_seek, _lfs_file_size, and _lfs_file_tell will return
+// functions lfs_file_seek_raw, lfs_file_size_raw, and lfs_file_tell_raw will return
 // incorrect values due to using signed integers. Stored in superblock and
 // must be respected by other littlefs drivers.
 #ifndef LFS_FILE_MAX
@@ -420,7 +420,7 @@ typedef struct lfs {
 // be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
-int _lfs_format(lfs_t *lfs, const struct lfs_config *config);
+int lfs_format_raw(lfs_t *lfs, const struct lfs_config *config);
 
 // Mounts a littlefs
 //
@@ -430,13 +430,13 @@ int _lfs_format(lfs_t *lfs, const struct lfs_config *config);
 // be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
-int _lfs_mount(lfs_t *lfs, const struct lfs_config *config);
+int lfs_mount_raw(lfs_t *lfs, const struct lfs_config *config);
 
 // Unmounts a littlefs
 //
 // Does nothing besides releasing any allocated resources.
 // Returns a negative error code on failure.
-int _lfs_unmount(lfs_t *lfs);
+int lfs_unmount_raw(lfs_t *lfs);
 
 /// General operations ///
 
@@ -444,7 +444,7 @@ int _lfs_unmount(lfs_t *lfs);
 //
 // If removing a directory, the directory must be empty.
 // Returns a negative error code on failure.
-int _lfs_remove(lfs_t *lfs, const char *path);
+int lfs_remove_raw(lfs_t *lfs, const char *path);
 
 // Rename or move a file or directory
 //
@@ -452,13 +452,13 @@ int _lfs_remove(lfs_t *lfs, const char *path);
 // If the destination is a directory, the directory must be empty.
 //
 // Returns a negative error code on failure.
-int _lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath);
+int lfs_rename_raw(lfs_t *lfs, const char *oldpath, const char *newpath);
 
 // Find info about a file or directory
 //
 // Fills out the info structure, based on the specified file or directory.
 // Returns a negative error code on failure.
-int _lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info);
+int lfs_stat_raw(lfs_t *lfs, const char *path, struct lfs_info *info);
 
 // Get a custom attribute
 //
@@ -472,7 +472,7 @@ int _lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info);
 // Note, the returned size is the size of the attribute on disk, irrespective
 // of the size of the buffer. This can be used to dynamically allocate a buffer
 // or check for existance.
-lfs_ssize_t _lfs_getattr(lfs_t *lfs, const char *path,
+lfs_ssize_t lfs_getattr_raw(lfs_t *lfs, const char *path,
         uint8_t type, void *buffer, lfs_size_t size);
 
 // Set custom attributes
@@ -482,7 +482,7 @@ lfs_ssize_t _lfs_getattr(lfs_t *lfs, const char *path,
 // implicitly created.
 //
 // Returns a negative error code on failure.
-int _lfs_setattr(lfs_t *lfs, const char *path,
+int lfs_setattr_raw(lfs_t *lfs, const char *path,
         uint8_t type, const void *buffer, lfs_size_t size);
 
 // Removes a custom attribute
@@ -490,7 +490,7 @@ int _lfs_setattr(lfs_t *lfs, const char *path,
 // If an attribute is not found, nothing happens.
 //
 // Returns a negative error code on failure.
-int _lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type);
+int lfs_removeattr_raw(lfs_t *lfs, const char *path, uint8_t type);
 
 
 /// File operations ///
@@ -501,7 +501,7 @@ int _lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type);
 // are values from the enum lfs_open_flags that are bitwise-ored together.
 //
 // Returns a negative error code on failure.
-int _lfs_file_open(lfs_t *lfs, lfs_file_t *file,
+int lfs_file_open_raw(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags);
 
 // Open a file with extra configuration
@@ -514,7 +514,7 @@ int _lfs_file_open(lfs_t *lfs, lfs_file_t *file,
 // config struct must be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
-int _lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
+int lfs_file_opencfg_raw(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags,
         const struct lfs_file_config *config);
 
@@ -524,19 +524,19 @@ int _lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
 // sync had been called and releases any allocated resources.
 //
 // Returns a negative error code on failure.
-int _lfs_file_close(lfs_t *lfs, lfs_file_t *file);
+int lfs_file_close_raw(lfs_t *lfs, lfs_file_t *file);
 
 // Synchronize a file on storage
 //
 // Any pending writes are written out to storage.
 // Returns a negative error code on failure.
-int _lfs_file_sync(lfs_t *lfs, lfs_file_t *file);
+int lfs_file_sync_raw(lfs_t *lfs, lfs_file_t *file);
 
 // Read data from file
 //
 // Takes a buffer and size indicating where to store the read data.
 // Returns the number of bytes read, or a negative error code on failure.
-lfs_ssize_t _lfs_file_read(lfs_t *lfs, lfs_file_t *file,
+lfs_ssize_t lfs_file_read_raw(lfs_t *lfs, lfs_file_t *file,
         void *buffer, lfs_size_t size);
 
 // Write data to file
@@ -545,38 +545,38 @@ lfs_ssize_t _lfs_file_read(lfs_t *lfs, lfs_file_t *file,
 // actually be updated on the storage until either sync or close is called.
 //
 // Returns the number of bytes written, or a negative error code on failure.
-lfs_ssize_t _lfs_file_write(lfs_t *lfs, lfs_file_t *file,
+lfs_ssize_t lfs_file_write_raw(lfs_t *lfs, lfs_file_t *file,
         const void *buffer, lfs_size_t size);
 
 // Change the position of the file
 //
 // The change in position is determined by the offset and whence flag.
 // Returns the new position of the file, or a negative error code on failure.
-lfs_soff_t _lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
+lfs_soff_t lfs_file_seek_raw(lfs_t *lfs, lfs_file_t *file,
         lfs_soff_t off, int whence);
 
 // Truncates the size of the file to the specified size
 //
 // Returns a negative error code on failure.
-int _lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
+int lfs_file_truncate_raw(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
 
 // Return the position of the file
 //
-// Equivalent to _lfs_file_seek(lfs, file, 0, LFS_SEEK_CUR)
+// Equivalent to lfs_file_seek_raw(lfs, file, 0, LFS_SEEK_CUR)
 // Returns the position of the file, or a negative error code on failure.
-lfs_soff_t _lfs_file_tell(lfs_t *lfs, lfs_file_t *file);
+lfs_soff_t lfs_file_tell_raw(lfs_t *lfs, lfs_file_t *file);
 
 // Change the position of the file to the beginning of the file
 //
-// Equivalent to _lfs_file_seek(lfs, file, 0, LFS_SEEK_SET)
+// Equivalent to lfs_file_seek_raw(lfs, file, 0, LFS_SEEK_SET)
 // Returns a negative error code on failure.
-int _lfs_file_rewind(lfs_t *lfs, lfs_file_t *file);
+int lfs_file_rewind_raw(lfs_t *lfs, lfs_file_t *file);
 
 // Return the size of the file
 //
-// Similar to _lfs_file_seek(lfs, file, 0, LFS_SEEK_END)
+// Similar to lfs_file_seek_raw(lfs, file, 0, LFS_SEEK_END)
 // Returns the size of the file, or a negative error code on failure.
-lfs_soff_t _lfs_file_size(lfs_t *lfs, lfs_file_t *file);
+lfs_soff_t lfs_file_size_raw(lfs_t *lfs, lfs_file_t *file);
 
 
 /// Directory operations ///
@@ -584,26 +584,26 @@ lfs_soff_t _lfs_file_size(lfs_t *lfs, lfs_file_t *file);
 // Create a directory
 //
 // Returns a negative error code on failure.
-int _lfs_mkdir(lfs_t *lfs, const char *path);
+int lfs_mkdir_raw(lfs_t *lfs, const char *path);
 
 // Open a directory
 //
 // Once open a directory can be used with read to iterate over files.
 // Returns a negative error code on failure.
-int _lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path);
+int lfs_dir_open_raw(lfs_t *lfs, lfs_dir_t *dir, const char *path);
 
 // Close a directory
 //
 // Releases any allocated resources.
 // Returns a negative error code on failure.
-int _lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir);
+int lfs_dir_close_raw(lfs_t *lfs, lfs_dir_t *dir);
 
 // Read an entry in the directory
 //
 // Fills out the info structure, based on the specified file or directory.
 // Returns a positive value on success, 0 at the end of directory,
 // or a negative error code on failure.
-int _lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
+int lfs_dir_read_raw(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
 
 // Change the position of the directory
 //
@@ -611,7 +611,7 @@ int _lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
 // an absolute offset in the directory seek.
 //
 // Returns a negative error code on failure.
-int _lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
+int lfs_dir_seek_raw(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
 
 // Return the position of the directory
 //
@@ -619,12 +619,12 @@ int _lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
 // sense, but does indicate the current position in the directory iteration.
 //
 // Returns the position of the directory, or a negative error code on failure.
-lfs_soff_t _lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir);
+lfs_soff_t lfs_dir_tell_raw(lfs_t *lfs, lfs_dir_t *dir);
 
 // Change the position of the directory to the beginning of the directory
 //
 // Returns a negative error code on failure.
-int _lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir);
+int lfs_dir_rewind_raw(lfs_t *lfs, lfs_dir_t *dir);
 
 
 /// Filesystem-level filesystem operations
@@ -635,7 +635,7 @@ int _lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir);
 // size may be larger than the filesystem actually is.
 //
 // Returns the number of allocated blocks, or a negative error code on failure.
-lfs_ssize_t _lfs_fs_size(lfs_t *lfs);
+lfs_ssize_t lfs_fs_size_raw(lfs_t *lfs);
 
 // Traverse through all blocks in use by the filesystem
 //
@@ -644,12 +644,12 @@ lfs_ssize_t _lfs_fs_size(lfs_t *lfs);
 // blocks are in use or how much of the storage is available.
 //
 // Returns a negative error code on failure.
-int _lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
+int lfs_fs_traverse_raw(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 
 #ifdef LFS_MIGRATE
 // Attempts to migrate a previous version of littlefs
 //
-// Behaves similarly to the _lfs_format function. Attempts to mount
+// Behaves similarly to the lfs_format_raw function. Attempts to mount
 // the previous version of littlefs and update the filesystem so it can be
 // mounted with the current version of littlefs.
 //
@@ -658,105 +658,105 @@ int _lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 // be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
-int _lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg);
+int lfs_migrate_raw(lfs_t *lfs, const struct lfs_config *cfg);
 #endif
 
 #if LFS_THREAD_SAFE
 
-int _ts_lfs_format(lfs_t *lfs, const struct lfs_config *config);
-int _ts_lfs_mount(lfs_t *lfs, const struct lfs_config *config);
-int _ts_lfs_unmount(lfs_t *lfs);
-int _ts_lfs_remove(lfs_t *lfs, const char *path);
-int _ts_lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath);
-int _ts_lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info);
-lfs_ssize_t _ts_lfs_getattr(lfs_t *lfs, const char *path, uint8_t type, void *buffer, lfs_size_t size);
-int _ts_lfs_setattr(lfs_t *lfs, const char *path, uint8_t type, const void *buffer, lfs_size_t size);
-int _ts_lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type);
-int _ts_lfs_file_open(lfs_t *lfs, lfs_file_t *file, const char *path, int flags);
-int _ts_lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, const struct lfs_file_config *config);
-int _ts_lfs_file_close(lfs_t *lfs, lfs_file_t *file);
-int _ts_lfs_file_sync(lfs_t *lfs, lfs_file_t *file);
-lfs_ssize_t _ts_lfs_file_read(lfs_t *lfs, lfs_file_t *file, void *buffer, lfs_size_t size);
-lfs_ssize_t _ts_lfs_file_write(lfs_t *lfs, lfs_file_t *file, const void *buffer, lfs_size_t size);
-lfs_soff_t _ts_lfs_file_seek(lfs_t *lfs, lfs_file_t *file, lfs_soff_t off, int whence);
-int _ts_lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
-lfs_soff_t _ts_lfs_file_tell(lfs_t *lfs, lfs_file_t *file);
-int _ts_lfs_file_rewind(lfs_t *lfs, lfs_file_t *file);
-lfs_soff_t _ts_lfs_file_size(lfs_t *lfs, lfs_file_t *file);
-int _ts_lfs_mkdir(lfs_t *lfs, const char *path);
-int _ts_lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path);
-int _ts_lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir);
-int _ts_lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
-int _ts_lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
-lfs_soff_t _ts_lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir);
-int _ts_lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir);
-lfs_ssize_t _ts_lfs_fs_size(lfs_t *lfs);
-int _ts_lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
-int _ts_lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg);
+int lfs_format_ts(lfs_t *lfs, const struct lfs_config *config);
+int lfs_mount_ts(lfs_t *lfs, const struct lfs_config *config);
+int lfs_unmount_ts(lfs_t *lfs);
+int lfs_remove_ts(lfs_t *lfs, const char *path);
+int lfs_rename_ts(lfs_t *lfs, const char *oldpath, const char *newpath);
+int lfs_stat_ts(lfs_t *lfs, const char *path, struct lfs_info *info);
+lfs_ssize_t lfs_getattr_ts(lfs_t *lfs, const char *path, uint8_t type, void *buffer, lfs_size_t size);
+int lfs_setattr_ts(lfs_t *lfs, const char *path, uint8_t type, const void *buffer, lfs_size_t size);
+int lfs_removeattr_ts(lfs_t *lfs, const char *path, uint8_t type);
+int lfs_file_open_ts(lfs_t *lfs, lfs_file_t *file, const char *path, int flags);
+int lfs_file_opencfg_ts(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, const struct lfs_file_config *config);
+int lfs_file_close_ts(lfs_t *lfs, lfs_file_t *file);
+int lfs_file_sync_ts(lfs_t *lfs, lfs_file_t *file);
+lfs_ssize_t lfs_file_read_ts(lfs_t *lfs, lfs_file_t *file, void *buffer, lfs_size_t size);
+lfs_ssize_t lfs_file_write_ts(lfs_t *lfs, lfs_file_t *file, const void *buffer, lfs_size_t size);
+lfs_soff_t lfs_file_seek_ts(lfs_t *lfs, lfs_file_t *file, lfs_soff_t off, int whence);
+int lfs_file_truncate_ts(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
+lfs_soff_t lfs_file_tell_ts(lfs_t *lfs, lfs_file_t *file);
+int lfs_file_rewind_ts(lfs_t *lfs, lfs_file_t *file);
+lfs_soff_t lfs_file_size_ts(lfs_t *lfs, lfs_file_t *file);
+int lfs_mkdir_ts(lfs_t *lfs, const char *path);
+int lfs_dir_open_ts(lfs_t *lfs, lfs_dir_t *dir, const char *path);
+int lfs_dir_close_ts(lfs_t *lfs, lfs_dir_t *dir);
+int lfs_dir_read_ts(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
+int lfs_dir_seek_ts(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
+lfs_soff_t lfs_dir_tell_ts(lfs_t *lfs, lfs_dir_t *dir);
+int lfs_dir_rewind_ts(lfs_t *lfs, lfs_dir_t *dir);
+lfs_ssize_t lfs_fs_size_ts(lfs_t *lfs);
+int lfs_fs_traverse_ts(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
+int lfs_migrate_ts(lfs_t *lfs, const struct lfs_config *cfg);
 
-#define lfs_format _ts_lfs_format
-#define lfs_mount _ts_lfs_mount
-#define lfs_unmount _ts_lfs_unmount
-#define lfs_remove _ts_lfs_remove
-#define lfs_rename _ts_lfs_rename
-#define lfs_stat _ts_lfs_stat
-#define lfs_getattr _ts_lfs_getattr
-#define lfs_setattr _ts_lfs_setattr
-#define lfs_removeattr _ts_lfs_removeattr
-#define lfs_file_open _ts_lfs_file_open
-#define lfs_file_opencfg _ts_lfs_file_opencfg
-#define lfs_file_close _ts_lfs_file_close
-#define lfs_file_sync _ts_lfs_file_sync
-#define lfs_file_read _ts_lfs_file_read
-#define lfs_file_write _ts_lfs_file_write
-#define lfs_file_seek _ts_lfs_file_seek
-#define lfs_file_truncate _ts_lfs_file_truncate
-#define lfs_file_tell _ts_lfs_file_tell
-#define lfs_file_rewind _ts_lfs_file_rewind
-#define lfs_file_size _ts_lfs_file_size
-#define lfs_mkdir _ts_lfs_mkdir
-#define lfs_dir_open _ts_lfs_dir_open
-#define lfs_dir_close _ts_lfs_dir_close
-#define lfs_dir_read _ts_lfs_dir_read
-#define lfs_dir_seek _ts_lfs_dir_seek
-#define lfs_dir_tell _ts_lfs_dir_tell
-#define lfs_dir_rewind _ts_lfs_dir_rewind
-#define lfs_fs_size _ts_lfs_fs_size
-#define lfs_fs_traverse _ts_lfs_fs_traverse
-#define lfs_migrate _ts_lfs_migrate
+#define lfs_format lfs_format_ts
+#define lfs_mount lfs_mount_ts
+#define lfs_unmount lfs_unmount_ts
+#define lfs_remove lfs_remove_ts
+#define lfs_rename lfs_rename_ts
+#define lfs_stat lfs_stat_ts
+#define lfs_getattr lfs_getattr_ts
+#define lfs_setattr lfs_setattr_ts
+#define lfs_removeattr lfs_removeattr_ts
+#define lfs_file_open lfs_file_open_ts
+#define lfs_file_opencfg lfs_file_opencfg_ts
+#define lfs_file_close lfs_file_close_ts
+#define lfs_file_sync lfs_file_sync_ts
+#define lfs_file_read lfs_file_read_ts
+#define lfs_file_write lfs_file_write_ts
+#define lfs_file_seek lfs_file_seek_ts
+#define lfs_file_truncate lfs_file_truncate_ts
+#define lfs_file_tell lfs_file_tell_ts
+#define lfs_file_rewind lfs_file_rewind_ts
+#define lfs_file_size lfs_file_size_ts
+#define lfs_mkdir lfs_mkdir_ts
+#define lfs_dir_open lfs_dir_open_ts
+#define lfs_dir_close lfs_dir_close_ts
+#define lfs_dir_read lfs_dir_read_ts
+#define lfs_dir_seek lfs_dir_seek_ts
+#define lfs_dir_tell lfs_dir_tell_ts
+#define lfs_dir_rewind lfs_dir_rewind_ts
+#define lfs_fs_size lfs_fs_size_ts
+#define lfs_fs_traverse lfs_fs_traverse_ts
+#define lfs_migrate lfs_migrate_ts
 
 #else
 
-#define lfs_format _lfs_format
-#define lfs_mount _lfs_mount
-#define lfs_unmount _lfs_unmount
-#define lfs_remove _lfs_remove
-#define lfs_rename _lfs_rename
-#define lfs_stat _lfs_stat
-#define lfs_getattr _lfs_getattr
-#define lfs_setattr _lfs_setattr
-#define lfs_removeattr _lfs_removeattr
-#define lfs_file_open _lfs_file_open
-#define lfs_file_opencfg _lfs_file_opencfg
-#define lfs_file_close _lfs_file_close
-#define lfs_file_sync _lfs_file_sync
-#define lfs_file_read _lfs_file_read
-#define lfs_file_write _lfs_file_write
-#define lfs_file_seek _lfs_file_seek
-#define lfs_file_truncate _lfs_file_truncate
-#define lfs_file_tell _lfs_file_tell
-#define lfs_file_rewind _lfs_file_rewind
-#define lfs_file_size _lfs_file_size
-#define lfs_mkdir _lfs_mkdir
-#define lfs_dir_open _lfs_dir_open
-#define lfs_dir_close _lfs_dir_close
-#define lfs_dir_read _lfs_dir_read
-#define lfs_dir_seek _lfs_dir_seek
-#define lfs_dir_tell _lfs_dir_tell
-#define lfs_dir_rewind _lfs_dir_rewind
-#define lfs_fs_size _lfs_fs_size
-#define lfs_fs_traverse _lfs_fs_traverse
-#define lfs_migrate _lfs_migrate
+#define lfs_format lfs_format_raw
+#define lfs_mount lfs_mount_raw
+#define lfs_unmount lfs_unmount_raw
+#define lfs_remove lfs_remove_raw
+#define lfs_rename lfs_rename_raw
+#define lfs_stat lfs_stat_raw
+#define lfs_getattr lfs_getattr_raw
+#define lfs_setattr lfs_setattr_raw
+#define lfs_removeattr lfs_removeattr_raw
+#define lfs_file_open lfs_file_open_raw
+#define lfs_file_opencfg lfs_file_opencfg_raw
+#define lfs_file_close lfs_file_close_raw
+#define lfs_file_sync lfs_file_sync_raw
+#define lfs_file_read lfs_file_read_raw
+#define lfs_file_write lfs_file_write_raw
+#define lfs_file_seek lfs_file_seek_raw
+#define lfs_file_truncate lfs_file_truncate_raw
+#define lfs_file_tell lfs_file_tell_raw
+#define lfs_file_rewind lfs_file_rewind_raw
+#define lfs_file_size lfs_file_size_raw
+#define lfs_mkdir lfs_mkdir_raw
+#define lfs_dir_open lfs_dir_open_raw
+#define lfs_dir_close lfs_dir_close_raw
+#define lfs_dir_read lfs_dir_read_raw
+#define lfs_dir_seek lfs_dir_seek_raw
+#define lfs_dir_tell lfs_dir_tell_raw
+#define lfs_dir_rewind lfs_dir_rewind_raw
+#define lfs_fs_size lfs_fs_size_raw
+#define lfs_fs_traverse lfs_fs_traverse_raw
+#define lfs_migrate lfs_migrate_raw
 
 #endif
 

--- a/lfs.h
+++ b/lfs.h
@@ -16,7 +16,6 @@ extern "C"
 {
 #endif
 
-
 /// Version info ///
 
 // Software library version
@@ -54,7 +53,7 @@ typedef uint32_t lfs_block_t;
 
 // Maximum size of a file in bytes, may be redefined to limit to support other
 // drivers. Limited on disk to <= 4294967296. However, above 2147483647 the
-// functions lfs_file_seek_raw, lfs_file_size_raw, and lfs_file_tell_raw will return
+// functions lfs_file_seek, lfs_file_size, and lfs_file_tell will return
 // incorrect values due to using signed integers. Stored in superblock and
 // must be respected by other littlefs drivers.
 #ifndef LFS_FILE_MAX
@@ -175,7 +174,7 @@ struct lfs_config {
     // are propogated to the user.
     int (*sync)(const struct lfs_config *c);
 
-    #if LFS_THREAD_SAFE
+#if LFS_THREADSAFE
     // Lock the underlying block device. Negative error codes
     // are propogated to the user.
     int (*lock)(const struct lfs_config *c);
@@ -183,7 +182,7 @@ struct lfs_config {
     // Unlock the underlying block device. Negative error codes
     // are propogated to the user.
     int (*unlock)(const struct lfs_config *c);
-    #endif
+#endif
 
     // Minimum size of a block read. All read operations will be a
     // multiple of this value.
@@ -417,7 +416,7 @@ typedef struct lfs {
 // be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
-int lfs_format_raw(lfs_t *lfs, const struct lfs_config *config);
+int lfs_format(lfs_t *lfs, const struct lfs_config *config);
 
 // Mounts a littlefs
 //
@@ -427,13 +426,13 @@ int lfs_format_raw(lfs_t *lfs, const struct lfs_config *config);
 // be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
-int lfs_mount_raw(lfs_t *lfs, const struct lfs_config *config);
+int lfs_mount(lfs_t *lfs, const struct lfs_config *config);
 
 // Unmounts a littlefs
 //
 // Does nothing besides releasing any allocated resources.
 // Returns a negative error code on failure.
-int lfs_unmount_raw(lfs_t *lfs);
+int lfs_unmount(lfs_t *lfs);
 
 /// General operations ///
 
@@ -441,7 +440,7 @@ int lfs_unmount_raw(lfs_t *lfs);
 //
 // If removing a directory, the directory must be empty.
 // Returns a negative error code on failure.
-int lfs_remove_raw(lfs_t *lfs, const char *path);
+int lfs_remove(lfs_t *lfs, const char *path);
 
 // Rename or move a file or directory
 //
@@ -449,13 +448,13 @@ int lfs_remove_raw(lfs_t *lfs, const char *path);
 // If the destination is a directory, the directory must be empty.
 //
 // Returns a negative error code on failure.
-int lfs_rename_raw(lfs_t *lfs, const char *oldpath, const char *newpath);
+int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath);
 
 // Find info about a file or directory
 //
 // Fills out the info structure, based on the specified file or directory.
 // Returns a negative error code on failure.
-int lfs_stat_raw(lfs_t *lfs, const char *path, struct lfs_info *info);
+int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info);
 
 // Get a custom attribute
 //
@@ -469,7 +468,7 @@ int lfs_stat_raw(lfs_t *lfs, const char *path, struct lfs_info *info);
 // Note, the returned size is the size of the attribute on disk, irrespective
 // of the size of the buffer. This can be used to dynamically allocate a buffer
 // or check for existance.
-lfs_ssize_t lfs_getattr_raw(lfs_t *lfs, const char *path,
+lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path,
         uint8_t type, void *buffer, lfs_size_t size);
 
 // Set custom attributes
@@ -479,7 +478,7 @@ lfs_ssize_t lfs_getattr_raw(lfs_t *lfs, const char *path,
 // implicitly created.
 //
 // Returns a negative error code on failure.
-int lfs_setattr_raw(lfs_t *lfs, const char *path,
+int lfs_setattr(lfs_t *lfs, const char *path,
         uint8_t type, const void *buffer, lfs_size_t size);
 
 // Removes a custom attribute
@@ -487,7 +486,7 @@ int lfs_setattr_raw(lfs_t *lfs, const char *path,
 // If an attribute is not found, nothing happens.
 //
 // Returns a negative error code on failure.
-int lfs_removeattr_raw(lfs_t *lfs, const char *path, uint8_t type);
+int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type);
 
 
 /// File operations ///
@@ -498,7 +497,7 @@ int lfs_removeattr_raw(lfs_t *lfs, const char *path, uint8_t type);
 // are values from the enum lfs_open_flags that are bitwise-ored together.
 //
 // Returns a negative error code on failure.
-int lfs_file_open_raw(lfs_t *lfs, lfs_file_t *file,
+int lfs_file_open(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags);
 
 // Open a file with extra configuration
@@ -511,7 +510,7 @@ int lfs_file_open_raw(lfs_t *lfs, lfs_file_t *file,
 // config struct must be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
-int lfs_file_opencfg_raw(lfs_t *lfs, lfs_file_t *file,
+int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags,
         const struct lfs_file_config *config);
 
@@ -521,19 +520,19 @@ int lfs_file_opencfg_raw(lfs_t *lfs, lfs_file_t *file,
 // sync had been called and releases any allocated resources.
 //
 // Returns a negative error code on failure.
-int lfs_file_close_raw(lfs_t *lfs, lfs_file_t *file);
+int lfs_file_close(lfs_t *lfs, lfs_file_t *file);
 
 // Synchronize a file on storage
 //
 // Any pending writes are written out to storage.
 // Returns a negative error code on failure.
-int lfs_file_sync_raw(lfs_t *lfs, lfs_file_t *file);
+int lfs_file_sync(lfs_t *lfs, lfs_file_t *file);
 
 // Read data from file
 //
 // Takes a buffer and size indicating where to store the read data.
 // Returns the number of bytes read, or a negative error code on failure.
-lfs_ssize_t lfs_file_read_raw(lfs_t *lfs, lfs_file_t *file,
+lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
         void *buffer, lfs_size_t size);
 
 // Write data to file
@@ -542,38 +541,38 @@ lfs_ssize_t lfs_file_read_raw(lfs_t *lfs, lfs_file_t *file,
 // actually be updated on the storage until either sync or close is called.
 //
 // Returns the number of bytes written, or a negative error code on failure.
-lfs_ssize_t lfs_file_write_raw(lfs_t *lfs, lfs_file_t *file,
+lfs_ssize_t lfs_file_write(lfs_t *lfs, lfs_file_t *file,
         const void *buffer, lfs_size_t size);
 
 // Change the position of the file
 //
 // The change in position is determined by the offset and whence flag.
 // Returns the new position of the file, or a negative error code on failure.
-lfs_soff_t lfs_file_seek_raw(lfs_t *lfs, lfs_file_t *file,
+lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
         lfs_soff_t off, int whence);
 
 // Truncates the size of the file to the specified size
 //
 // Returns a negative error code on failure.
-int lfs_file_truncate_raw(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
+int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
 
 // Return the position of the file
 //
-// Equivalent to lfs_file_seek_raw(lfs, file, 0, LFS_SEEK_CUR)
+// Equivalent to lfs_file_seek(lfs, file, 0, LFS_SEEK_CUR)
 // Returns the position of the file, or a negative error code on failure.
-lfs_soff_t lfs_file_tell_raw(lfs_t *lfs, lfs_file_t *file);
+lfs_soff_t lfs_file_tell(lfs_t *lfs, lfs_file_t *file);
 
 // Change the position of the file to the beginning of the file
 //
-// Equivalent to lfs_file_seek_raw(lfs, file, 0, LFS_SEEK_SET)
+// Equivalent to lfs_file_seek(lfs, file, 0, LFS_SEEK_SET)
 // Returns a negative error code on failure.
-int lfs_file_rewind_raw(lfs_t *lfs, lfs_file_t *file);
+int lfs_file_rewind(lfs_t *lfs, lfs_file_t *file);
 
 // Return the size of the file
 //
-// Similar to lfs_file_seek_raw(lfs, file, 0, LFS_SEEK_END)
+// Similar to lfs_file_seek(lfs, file, 0, LFS_SEEK_END)
 // Returns the size of the file, or a negative error code on failure.
-lfs_soff_t lfs_file_size_raw(lfs_t *lfs, lfs_file_t *file);
+lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file);
 
 
 /// Directory operations ///
@@ -581,26 +580,26 @@ lfs_soff_t lfs_file_size_raw(lfs_t *lfs, lfs_file_t *file);
 // Create a directory
 //
 // Returns a negative error code on failure.
-int lfs_mkdir_raw(lfs_t *lfs, const char *path);
+int lfs_mkdir(lfs_t *lfs, const char *path);
 
 // Open a directory
 //
 // Once open a directory can be used with read to iterate over files.
 // Returns a negative error code on failure.
-int lfs_dir_open_raw(lfs_t *lfs, lfs_dir_t *dir, const char *path);
+int lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path);
 
 // Close a directory
 //
 // Releases any allocated resources.
 // Returns a negative error code on failure.
-int lfs_dir_close_raw(lfs_t *lfs, lfs_dir_t *dir);
+int lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir);
 
 // Read an entry in the directory
 //
 // Fills out the info structure, based on the specified file or directory.
 // Returns a positive value on success, 0 at the end of directory,
 // or a negative error code on failure.
-int lfs_dir_read_raw(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
+int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
 
 // Change the position of the directory
 //
@@ -608,7 +607,7 @@ int lfs_dir_read_raw(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
 // an absolute offset in the directory seek.
 //
 // Returns a negative error code on failure.
-int lfs_dir_seek_raw(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
+int lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
 
 // Return the position of the directory
 //
@@ -616,12 +615,12 @@ int lfs_dir_seek_raw(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
 // sense, but does indicate the current position in the directory iteration.
 //
 // Returns the position of the directory, or a negative error code on failure.
-lfs_soff_t lfs_dir_tell_raw(lfs_t *lfs, lfs_dir_t *dir);
+lfs_soff_t lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir);
 
 // Change the position of the directory to the beginning of the directory
 //
 // Returns a negative error code on failure.
-int lfs_dir_rewind_raw(lfs_t *lfs, lfs_dir_t *dir);
+int lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir);
 
 
 /// Filesystem-level filesystem operations
@@ -632,7 +631,7 @@ int lfs_dir_rewind_raw(lfs_t *lfs, lfs_dir_t *dir);
 // size may be larger than the filesystem actually is.
 //
 // Returns the number of allocated blocks, or a negative error code on failure.
-lfs_ssize_t lfs_fs_size_raw(lfs_t *lfs);
+lfs_ssize_t lfs_fs_size(lfs_t *lfs);
 
 // Traverse through all blocks in use by the filesystem
 //
@@ -641,12 +640,12 @@ lfs_ssize_t lfs_fs_size_raw(lfs_t *lfs);
 // blocks are in use or how much of the storage is available.
 //
 // Returns a negative error code on failure.
-int lfs_fs_traverse_raw(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
+int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 
 #ifdef LFS_MIGRATE
 // Attempts to migrate a previous version of littlefs
 //
-// Behaves similarly to the lfs_format_raw function. Attempts to mount
+// Behaves similarly to the lfs_format function. Attempts to mount
 // the previous version of littlefs and update the filesystem so it can be
 // mounted with the current version of littlefs.
 //
@@ -655,108 +654,39 @@ int lfs_fs_traverse_raw(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 // be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
+int lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg);
+#endif
+
+int lfs_format_raw(lfs_t *lfs, const struct lfs_config *config);
+int lfs_mount_raw(lfs_t *lfs, const struct lfs_config *config);
+int lfs_unmount_raw(lfs_t *lfs);
+int lfs_remove_raw(lfs_t *lfs, const char *path);
+int lfs_rename_raw(lfs_t *lfs, const char *oldpath, const char *newpath);
+int lfs_stat_raw(lfs_t *lfs, const char *path, struct lfs_info *info);
+lfs_ssize_t lfs_getattr_raw(lfs_t *lfs, const char *path, uint8_t type, void *buffer, lfs_size_t size);
+int lfs_setattr_raw(lfs_t *lfs, const char *path, uint8_t type, const void *buffer, lfs_size_t size);
+int lfs_removeattr_raw(lfs_t *lfs, const char *path, uint8_t type);
+int lfs_file_open_raw(lfs_t *lfs, lfs_file_t *file, const char *path, int flags);
+int lfs_file_opencfg_raw(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, const struct lfs_file_config *config);
+int lfs_file_close_raw(lfs_t *lfs, lfs_file_t *file);
+int lfs_file_sync_raw(lfs_t *lfs, lfs_file_t *file);
+lfs_ssize_t lfs_file_read_raw(lfs_t *lfs, lfs_file_t *file, void *buffer, lfs_size_t size);
+lfs_ssize_t lfs_file_write_raw(lfs_t *lfs, lfs_file_t *file, const void *buffer, lfs_size_t size);
+lfs_soff_t lfs_file_seek_raw(lfs_t *lfs, lfs_file_t *file, lfs_soff_t off, int whence);
+int lfs_file_truncate_raw(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
+lfs_soff_t lfs_file_tell_raw(lfs_t *lfs, lfs_file_t *file);
+int lfs_file_rewind_raw(lfs_t *lfs, lfs_file_t *file);
+lfs_soff_t lfs_file_size_raw(lfs_t *lfs, lfs_file_t *file);
+int lfs_mkdir_raw(lfs_t *lfs, const char *path);
+int lfs_dir_open_raw(lfs_t *lfs, lfs_dir_t *dir, const char *path);
+int lfs_dir_close_raw(lfs_t *lfs, lfs_dir_t *dir);
+int lfs_dir_read_raw(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
+int lfs_dir_seek_raw(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
+lfs_soff_t lfs_dir_tell_raw(lfs_t *lfs, lfs_dir_t *dir);
+int lfs_dir_rewind_raw(lfs_t *lfs, lfs_dir_t *dir);
+lfs_ssize_t lfs_fs_size_raw(lfs_t *lfs);
+int lfs_fs_traverse_raw(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 int lfs_migrate_raw(lfs_t *lfs, const struct lfs_config *cfg);
-#endif
-
-#if LFS_THREAD_SAFE
-
-int lfs_format_ts(lfs_t *lfs, const struct lfs_config *config);
-int lfs_mount_ts(lfs_t *lfs, const struct lfs_config *config);
-int lfs_unmount_ts(lfs_t *lfs);
-int lfs_remove_ts(lfs_t *lfs, const char *path);
-int lfs_rename_ts(lfs_t *lfs, const char *oldpath, const char *newpath);
-int lfs_stat_ts(lfs_t *lfs, const char *path, struct lfs_info *info);
-lfs_ssize_t lfs_getattr_ts(lfs_t *lfs, const char *path, uint8_t type, void *buffer, lfs_size_t size);
-int lfs_setattr_ts(lfs_t *lfs, const char *path, uint8_t type, const void *buffer, lfs_size_t size);
-int lfs_removeattr_ts(lfs_t *lfs, const char *path, uint8_t type);
-int lfs_file_open_ts(lfs_t *lfs, lfs_file_t *file, const char *path, int flags);
-int lfs_file_opencfg_ts(lfs_t *lfs, lfs_file_t *file, const char *path, int flags, const struct lfs_file_config *config);
-int lfs_file_close_ts(lfs_t *lfs, lfs_file_t *file);
-int lfs_file_sync_ts(lfs_t *lfs, lfs_file_t *file);
-lfs_ssize_t lfs_file_read_ts(lfs_t *lfs, lfs_file_t *file, void *buffer, lfs_size_t size);
-lfs_ssize_t lfs_file_write_ts(lfs_t *lfs, lfs_file_t *file, const void *buffer, lfs_size_t size);
-lfs_soff_t lfs_file_seek_ts(lfs_t *lfs, lfs_file_t *file, lfs_soff_t off, int whence);
-int lfs_file_truncate_ts(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
-lfs_soff_t lfs_file_tell_ts(lfs_t *lfs, lfs_file_t *file);
-int lfs_file_rewind_ts(lfs_t *lfs, lfs_file_t *file);
-lfs_soff_t lfs_file_size_ts(lfs_t *lfs, lfs_file_t *file);
-int lfs_mkdir_ts(lfs_t *lfs, const char *path);
-int lfs_dir_open_ts(lfs_t *lfs, lfs_dir_t *dir, const char *path);
-int lfs_dir_close_ts(lfs_t *lfs, lfs_dir_t *dir);
-int lfs_dir_read_ts(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
-int lfs_dir_seek_ts(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
-lfs_soff_t lfs_dir_tell_ts(lfs_t *lfs, lfs_dir_t *dir);
-int lfs_dir_rewind_ts(lfs_t *lfs, lfs_dir_t *dir);
-lfs_ssize_t lfs_fs_size_ts(lfs_t *lfs);
-int lfs_fs_traverse_ts(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
-int lfs_migrate_ts(lfs_t *lfs, const struct lfs_config *cfg);
-
-#define lfs_format lfs_format_ts
-#define lfs_mount lfs_mount_ts
-#define lfs_unmount lfs_unmount_ts
-#define lfs_remove lfs_remove_ts
-#define lfs_rename lfs_rename_ts
-#define lfs_stat lfs_stat_ts
-#define lfs_getattr lfs_getattr_ts
-#define lfs_setattr lfs_setattr_ts
-#define lfs_removeattr lfs_removeattr_ts
-#define lfs_file_open lfs_file_open_ts
-#define lfs_file_opencfg lfs_file_opencfg_ts
-#define lfs_file_close lfs_file_close_ts
-#define lfs_file_sync lfs_file_sync_ts
-#define lfs_file_read lfs_file_read_ts
-#define lfs_file_write lfs_file_write_ts
-#define lfs_file_seek lfs_file_seek_ts
-#define lfs_file_truncate lfs_file_truncate_ts
-#define lfs_file_tell lfs_file_tell_ts
-#define lfs_file_rewind lfs_file_rewind_ts
-#define lfs_file_size lfs_file_size_ts
-#define lfs_mkdir lfs_mkdir_ts
-#define lfs_dir_open lfs_dir_open_ts
-#define lfs_dir_close lfs_dir_close_ts
-#define lfs_dir_read lfs_dir_read_ts
-#define lfs_dir_seek lfs_dir_seek_ts
-#define lfs_dir_tell lfs_dir_tell_ts
-#define lfs_dir_rewind lfs_dir_rewind_ts
-#define lfs_fs_size lfs_fs_size_ts
-#define lfs_fs_traverse lfs_fs_traverse_ts
-#define lfs_migrate lfs_migrate_ts
-
-#else
-
-#define lfs_format lfs_format_raw
-#define lfs_mount lfs_mount_raw
-#define lfs_unmount lfs_unmount_raw
-#define lfs_remove lfs_remove_raw
-#define lfs_rename lfs_rename_raw
-#define lfs_stat lfs_stat_raw
-#define lfs_getattr lfs_getattr_raw
-#define lfs_setattr lfs_setattr_raw
-#define lfs_removeattr lfs_removeattr_raw
-#define lfs_file_open lfs_file_open_raw
-#define lfs_file_opencfg lfs_file_opencfg_raw
-#define lfs_file_close lfs_file_close_raw
-#define lfs_file_sync lfs_file_sync_raw
-#define lfs_file_read lfs_file_read_raw
-#define lfs_file_write lfs_file_write_raw
-#define lfs_file_seek lfs_file_seek_raw
-#define lfs_file_truncate lfs_file_truncate_raw
-#define lfs_file_tell lfs_file_tell_raw
-#define lfs_file_rewind lfs_file_rewind_raw
-#define lfs_file_size lfs_file_size_raw
-#define lfs_mkdir lfs_mkdir_raw
-#define lfs_dir_open lfs_dir_open_raw
-#define lfs_dir_close lfs_dir_close_raw
-#define lfs_dir_read lfs_dir_read_raw
-#define lfs_dir_seek lfs_dir_seek_raw
-#define lfs_dir_tell lfs_dir_tell_raw
-#define lfs_dir_rewind lfs_dir_rewind_raw
-#define lfs_fs_size lfs_fs_size_raw
-#define lfs_fs_traverse lfs_fs_traverse_raw
-#define lfs_migrate lfs_migrate_raw
-
-#endif
-
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/lfs.h
+++ b/lfs.h
@@ -9,7 +9,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "lfs_util.h"
+#include <lfs_util.h>
 
 #ifdef __cplusplus
 extern "C"

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -44,8 +44,8 @@ extern "C"
 #endif
 
 // Enables thread-safe wrappers using the lock/unlock callbacks in lfs_config
-#ifndef LFS_THREAD_SAFE
-#define LFS_THREAD_SAFE 0
+#ifndef LFS_THREADSAFE
+#define LFS_THREADSAFE 0
 #endif
 
 // Macros, may be replaced by system specific wrappers. Arguments to these

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -43,6 +43,9 @@ extern "C"
 {
 #endif
 
+#ifndef LFS_THREAD_SAFE
+#define LFS_THREAD_SAFE 0
+#endif
 
 // Macros, may be replaced by system specific wrappers. Arguments to these
 // macros must not have side-effects as the macros can be removed for a smaller

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -43,6 +43,7 @@ extern "C"
 {
 #endif
 
+// Enables thread-safe wrappers using the lock/unlock callbacks in lfs_config
 #ifndef LFS_THREAD_SAFE
 #define LFS_THREAD_SAFE 0
 #endif


### PR DESCRIPTION
I'm working on an optional thread safe wrapper for the top level LittleFS APIs. I'm currently trying to sort out a few outstanding issues but the general design is there. When LFS_THREAD_SAFE is enabled all lfs calls will be routed through the locking wrappers otherwise all that code will be compiled out and function as normal.

We are testing using AWS IoT qualification tests but have not added any tests to the test suite.

Please let me know your thoughts.