### PR TITLE
Add LFS_READONLY define, to allow smaller builds providing read-only mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -208,6 +208,22 @@ jobs:
     script:
       - make test TFLAGS+="-k --valgrind"
 
+  # test compilation in read-only mode
+  - stage: test
+    env:
+      - NAME=littlefs-readonly
+      - CC="arm-linux-gnueabi-gcc --static -mthumb"
+      - CFLAGS="-Werror -DLFS_READONLY"
+    if: branch !~ -prefix$
+    install:
+      - *install-common
+      - sudo apt-get install
+            gcc-arm-linux-gnueabi
+            libc6-dev-armel-cross
+      - arm-linux-gnueabi-gcc --version
+    # report-size will compile littlefs and report the size
+    script: [*report-size]
+
   # self-host with littlefs-fuse for fuzz test
   - stage: test
     env:

--- a/lfs.c
+++ b/lfs.c
@@ -2592,7 +2592,9 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
 
 cleanup:
     // clean up lingering resources
+#ifndef LFS_READONLY
     file->flags |= LFS_F_ERRED;
+#endif
     lfs_file_close(lfs, file);
     LFS_TRACE("lfs_file_opencfg -> %d", err);
     return err;

--- a/lfs.c
+++ b/lfs.c
@@ -169,7 +169,7 @@ static int lfs_bd_flush(lfs_t *lfs,
 
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_bd_sync(lfs_t *lfs,
@@ -185,7 +185,7 @@ static int lfs_bd_sync(lfs_t *lfs,
     LFS_ASSERT(err <= 0);
     return err;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_bd_prog(lfs_t *lfs,
@@ -233,7 +233,7 @@ static int lfs_bd_prog(lfs_t *lfs,
 
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_bd_erase(lfs_t *lfs, lfs_block_t block) {
@@ -242,7 +242,7 @@ static int lfs_bd_erase(lfs_t *lfs, lfs_block_t block) {
     LFS_ASSERT(err <= 0);
     return err;
 }
-#endif /* LFS_READONLY */
+#endif
 
 
 /// Small type-level utilities ///
@@ -401,7 +401,7 @@ static void lfs_ctz_tole32(struct lfs_ctz *ctz) {
     ctz->head = lfs_tole32(ctz->head);
     ctz->size = lfs_tole32(ctz->size);
 }
-#endif /* LFS_READONLY */
+#endif
 
 static inline void lfs_superblock_fromle32(lfs_superblock_t *superblock) {
     superblock->version     = lfs_fromle32(superblock->version);
@@ -440,18 +440,18 @@ static lfs_stag_t lfs_fs_parent(lfs_t *lfs, const lfs_block_t dir[2],
         lfs_mdir_t *parent);
 static int lfs_fs_relocate(lfs_t *lfs,
         const lfs_block_t oldpair[2], lfs_block_t newpair[2]);
-#endif /* LFS_READONLY */
+#endif
 int lfs_fs_traverseraw(lfs_t *lfs,
         int (*cb)(void *data, lfs_block_t block), void *data,
         bool includeorphans);
 #ifndef LFS_READONLY
 static int lfs_fs_forceconsistency(lfs_t *lfs);
-#endif /* LFS_READONLY */
+#endif
 static int lfs_deinit(lfs_t *lfs);
 #ifdef LFS_MIGRATE
 static int lfs1_traverse(lfs_t *lfs,
         int (*cb)(void*, lfs_block_t), void *data);
-#endif /* LFS_MIGRATE */
+#endif
 
 /// Block allocator ///
 #ifndef LFS_READONLY
@@ -466,7 +466,7 @@ static int lfs_alloc_lookahead(void *p, lfs_block_t block) {
 
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 static void lfs_alloc_ack(lfs_t *lfs) {
     lfs->free.ack = lfs->cfg->block_count;
@@ -527,7 +527,7 @@ static int lfs_alloc(lfs_t *lfs, lfs_block_t *block) {
         }
     }
 }
-#endif /* LFS_READONLY */
+#endif
 
 /// Metadata pair and directory operations ///
 static lfs_stag_t lfs_dir_getslice(lfs_t *lfs, const lfs_mdir_t *dir,
@@ -688,7 +688,7 @@ static int lfs_dir_traverse_filter(void *p,
 
     return false;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_dir_traverse(lfs_t *lfs,
@@ -784,7 +784,7 @@ static int lfs_dir_traverse(lfs_t *lfs,
         }
     }
 }
-#endif /* LFS_READONLY */
+#endif
 
 static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
         lfs_mdir_t *dir, const lfs_block_t pair[2],
@@ -1237,7 +1237,7 @@ static int lfs_dir_commitprog(lfs_t *lfs, struct lfs_commit *commit,
     commit->off += size;
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_dir_commitattr(lfs_t *lfs, struct lfs_commit *commit,
@@ -1284,7 +1284,7 @@ static int lfs_dir_commitattr(lfs_t *lfs, struct lfs_commit *commit,
     commit->ptag = tag & 0x7fffffff;
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_dir_commitcrc(lfs_t *lfs, struct lfs_commit *commit) {
@@ -1379,7 +1379,7 @@ static int lfs_dir_commitcrc(lfs_t *lfs, struct lfs_commit *commit) {
 
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_dir_alloc(lfs_t *lfs, lfs_mdir_t *dir) {
@@ -1419,7 +1419,7 @@ static int lfs_dir_alloc(lfs_t *lfs, lfs_mdir_t *dir) {
     // don't write out yet, let caller take care of that
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_dir_drop(lfs_t *lfs, lfs_mdir_t *dir, lfs_mdir_t *tail) {
@@ -1440,7 +1440,7 @@ static int lfs_dir_drop(lfs_t *lfs, lfs_mdir_t *dir, lfs_mdir_t *tail) {
 
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_dir_split(lfs_t *lfs,
@@ -1475,7 +1475,7 @@ static int lfs_dir_split(lfs_t *lfs,
 
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_dir_commit_size(void *p, lfs_tag_t tag, const void *buffer) {
@@ -1485,21 +1485,21 @@ static int lfs_dir_commit_size(void *p, lfs_tag_t tag, const void *buffer) {
     *size += lfs_tag_dsize(tag);
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 struct lfs_dir_commit_commit {
     lfs_t *lfs;
     struct lfs_commit *commit;
 };
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_dir_commit_commit(void *p, lfs_tag_t tag, const void *buffer) {
     struct lfs_dir_commit_commit *commit = p;
     return lfs_dir_commitattr(commit->lfs, commit->commit, tag, buffer);
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_dir_compact(lfs_t *lfs,
@@ -1595,7 +1595,7 @@ static int lfs_dir_compact(lfs_t *lfs,
             // pointers if we relocate the head of a directory. On top of
             // this, relocations increase the overall complexity of
             // lfs_migration, which is already a delicate operation.
-#endif /* LFS_MIGRATE */
+#endif
         } else {
             // we're writing too much, time to relocate
             tired = true;
@@ -1756,7 +1756,7 @@ relocate:
 
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_dir_commit(lfs_t *lfs, lfs_mdir_t *dir,
@@ -1946,7 +1946,7 @@ compact:
 
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 
 /// Top level directory operations ///
@@ -2049,7 +2049,7 @@ int lfs_mkdir(lfs_t *lfs, const char *path) {
     LFS_TRACE("lfs_mkdir -> %d", 0);
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 int lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
     LFS_TRACE("lfs_dir_open(%p, %p, \"%s\")", (void*)lfs, (void*)dir, path);
@@ -2381,7 +2381,7 @@ relocate:
         lfs_cache_drop(lfs, pcache);
     }
 }
-#endif /* LFS_READONLY */
+#endif
 
 static int lfs_ctz_traverse(lfs_t *lfs,
         const lfs_cache_t *pcache, lfs_cache_t *rcache,
@@ -2447,7 +2447,7 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
             return err;
         }
     }
-#endif /* LFS_READONLY */
+#endif
 
     // setup simple file details
     int err;
@@ -2500,7 +2500,7 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
     } else if (flags & LFS_O_EXCL) {
         err = LFS_ERR_EXIST;
         goto cleanup;
-#endif /* LFS_READONLY */
+#endif
     } else if (lfs_tag_type3(tag) != LFS_TYPE_REG) {
         err = LFS_ERR_ISDIR;
         goto cleanup;
@@ -2509,7 +2509,7 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
         // truncate if requested
         tag = LFS_MKTAG(LFS_TYPE_INLINESTRUCT, file->id, 0);
         file->flags |= LFS_F_DIRTY;
-#endif /* LFS_READONLY */
+#endif
     } else {
         // try to load what's on disk, if it's inlined we'll fix it later
         tag = lfs_dir_get(lfs, &file->m, LFS_MKTAG(0x700, 0x3ff, 0),
@@ -2527,7 +2527,7 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
         /* always LFS_O_RDONLY */
 #else
         if ((file->flags & 3) != LFS_O_WRONLY)
-#endif /* LFS_READONLY */
+#endif
         {
             lfs_stag_t res = lfs_dir_get(lfs, &file->m,
                     LFS_MKTAG(0x7ff, 0x3ff, 0),
@@ -2549,7 +2549,7 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
 
             file->flags |= LFS_F_DIRTY;
         }
-#endif /* LFS_READONLY */
+#endif
     }
 
     // allocate buffer if needed
@@ -2618,7 +2618,7 @@ int lfs_file_close(lfs_t *lfs, lfs_file_t *file) {
     int err = 0;
 #else
     int err = lfs_file_sync(lfs, file);
-#endif /* LFS_READONLY */
+#endif
 
     // remove from list of mdirs
     for (struct lfs_mlist **p = &lfs->mlist; *p; p = &(*p)->next) {
@@ -2710,7 +2710,7 @@ relocate:
         lfs_cache_drop(lfs, &lfs->pcache);
     }
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_file_outline(lfs_t *lfs, lfs_file_t *file) {
@@ -2724,7 +2724,7 @@ static int lfs_file_outline(lfs_t *lfs, lfs_file_t *file) {
     file->flags &= ~LFS_F_INLINE;
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_file_flush(lfs_t *lfs, lfs_file_t *file) {
@@ -2806,7 +2806,7 @@ relocate:
 
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
@@ -2866,7 +2866,7 @@ int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_sync -> %d", 0);
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
         void *buffer, lfs_size_t size) {
@@ -2877,7 +2877,7 @@ lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
     /* always LFS_O_RDONLY */
 #else
     LFS_ASSERT((file->flags & 3) != LFS_O_WRONLY);
-#endif /* LFS_READONLY */
+#endif
 
     uint8_t *data = buffer;
     lfs_size_t nsize = size;
@@ -2891,7 +2891,7 @@ lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
             return err;
         }
     }
-#endif /* LFS_READONLY */
+#endif
 
     if (file->pos >= file->ctz.size) {
         // eof if past end
@@ -3085,7 +3085,7 @@ relocate:
     LFS_TRACE("lfs_file_write -> %"PRId32, size);
     return size;
 }
-#endif /* LFS_READONLY */
+#endif
 
 lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
         lfs_soff_t off, int whence) {
@@ -3100,7 +3100,7 @@ lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
         LFS_TRACE("lfs_file_seek -> %d", err);
         return err;
     }
-#endif /* LFS_READONLY */
+#endif
 
     // find new pos
     lfs_off_t npos = file->pos;
@@ -3188,7 +3188,7 @@ int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     LFS_TRACE("lfs_file_truncate -> %d", 0);
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 lfs_soff_t lfs_file_tell(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_tell(%p, %p)", (void*)lfs, (void*)file);
@@ -3221,7 +3221,7 @@ lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file) {
                 lfs_max(file->pos, file->ctz.size));
         return lfs_max(file->pos, file->ctz.size);
     } else
-#endif /* LFS_READONLY */
+#endif
     {
         LFS_TRACE("lfs_file_size -> %"PRId32, file->ctz.size);
         return file->ctz.size;
@@ -3326,7 +3326,7 @@ int lfs_remove(lfs_t *lfs, const char *path) {
     LFS_TRACE("lfs_remove -> %d", 0);
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
@@ -3473,7 +3473,7 @@ int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
     LFS_TRACE("lfs_rename -> %d", 0);
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path,
         uint8_t type, void *buffer, lfs_size_t size) {
@@ -3538,7 +3538,7 @@ static int lfs_commitattr(lfs_t *lfs, const char *path,
     return lfs_dir_commit(lfs, &cwd, LFS_MKATTRS(
             {LFS_MKTAG(LFS_TYPE_USERATTR + type, id, size), buffer}));
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 int lfs_setattr(lfs_t *lfs, const char *path,
@@ -3554,7 +3554,7 @@ int lfs_setattr(lfs_t *lfs, const char *path,
     LFS_TRACE("lfs_setattr -> %d", err);
     return err;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type) {
@@ -3563,7 +3563,7 @@ int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type) {
     LFS_TRACE("lfs_removeattr -> %d", err);
     return err;
 }
-#endif /* LFS_READONLY */
+#endif
 
 
 /// Filesystem operations ///
@@ -3665,7 +3665,7 @@ static int lfs_init(lfs_t *lfs, const struct lfs_config *cfg) {
     lfs->gdelta = (lfs_gstate_t){0};
 #ifdef LFS_MIGRATE
     lfs->lfs1 = NULL;
-#endif /* LFS_MIGRATE */
+#endif
 
     return 0;
 
@@ -3774,7 +3774,7 @@ cleanup:
     return err;
 
 }
-#endif /* LFS_READONLY */
+#endif
 
 int lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
     LFS_TRACE("lfs_mount(%p, %p {.context=%p, "
@@ -3946,7 +3946,7 @@ int lfs_fs_traverseraw(lfs_t *lfs,
         dir.tail[0] = lfs->root[0];
         dir.tail[1] = lfs->root[1];
     }
-#endif /* LFS_MIGRATE */
+#endif
 
     lfs_block_t cycle = 0;
     while (!lfs_pair_isnull(dir.tail)) {
@@ -4021,7 +4021,7 @@ int lfs_fs_traverseraw(lfs_t *lfs,
                 return err;
             }
         }
-#endif /* LFS_READONLY */
+#endif
     }
 
     return 0;
@@ -4062,14 +4062,14 @@ static int lfs_fs_pred(lfs_t *lfs,
 
     return LFS_ERR_NOENT;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 struct lfs_fs_parent_match {
     lfs_t *lfs;
     const lfs_block_t pair[2];
 };
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_fs_parent_match(void *data,
@@ -4090,7 +4090,7 @@ static int lfs_fs_parent_match(void *data,
     lfs_pair_fromle32(child);
     return (lfs_pair_cmp(child, find->pair) == 0) ? LFS_CMP_EQ : LFS_CMP_LT;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static lfs_stag_t lfs_fs_parent(lfs_t *lfs, const lfs_block_t pair[2],
@@ -4119,7 +4119,7 @@ static lfs_stag_t lfs_fs_parent(lfs_t *lfs, const lfs_block_t pair[2],
 
     return LFS_ERR_NOENT;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_fs_relocate(lfs_t *lfs,
@@ -4216,7 +4216,7 @@ static int lfs_fs_relocate(lfs_t *lfs,
 
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static void lfs_fs_preporphans(lfs_t *lfs, int8_t orphans) {
@@ -4225,7 +4225,7 @@ static void lfs_fs_preporphans(lfs_t *lfs, int8_t orphans) {
     lfs->gstate.tag = ((lfs->gstate.tag & ~LFS_MKTAG(0x800, 0, 0)) |
             ((uint32_t)lfs_gstate_hasorphans(&lfs->gstate) << 31));
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static void lfs_fs_prepmove(lfs_t *lfs,
@@ -4235,7 +4235,7 @@ static void lfs_fs_prepmove(lfs_t *lfs,
     lfs->gstate.pair[0] = (id != 0x3ff) ? pair[0] : 0;
     lfs->gstate.pair[1] = (id != 0x3ff) ? pair[1] : 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_fs_demove(lfs_t *lfs) {
@@ -4267,7 +4267,7 @@ static int lfs_fs_demove(lfs_t *lfs) {
 
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_fs_deorphan(lfs_t *lfs) {
@@ -4343,7 +4343,7 @@ static int lfs_fs_deorphan(lfs_t *lfs) {
     lfs_fs_preporphans(lfs, -lfs_gstate_getorphans(&lfs->gstate));
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 #ifndef LFS_READONLY
 static int lfs_fs_forceconsistency(lfs_t *lfs) {
@@ -4359,7 +4359,7 @@ static int lfs_fs_forceconsistency(lfs_t *lfs) {
 
     return 0;
 }
-#endif /* LFS_READONLY */
+#endif
 
 static int lfs_fs_size_count(void *p, lfs_block_t block) {
     (void)block;
@@ -5043,4 +5043,4 @@ cleanup:
     return err;
 }
 
-#endif /* LFS_MIGRATE */
+#endif

--- a/lfs.c
+++ b/lfs.c
@@ -3996,6 +3996,7 @@ int lfs_fs_traverseraw(lfs_t *lfs,
         }
     }
 
+#ifndef LFS_READONLY
     // iterate over any open files
     for (lfs_file_t *f = (lfs_file_t*)lfs->mlist; f; f = f->next) {
         if (f->type != LFS_TYPE_REG) {
@@ -4010,7 +4011,6 @@ int lfs_fs_traverseraw(lfs_t *lfs,
             }
         }
 
-#ifndef LFS_READONLY
         if ((f->flags & LFS_F_WRITING) && !(f->flags & LFS_F_INLINE)) {
             int err = lfs_ctz_traverse(lfs, &f->cache, &lfs->rcache,
                     f->block, f->pos, cb, data);
@@ -4018,8 +4018,8 @@ int lfs_fs_traverseraw(lfs_t *lfs,
                 return err;
             }
         }
-#endif
     }
+#endif
 
     return 0;
 }

--- a/lfs.c
+++ b/lfs.c
@@ -2469,11 +2469,12 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
     file->next = (lfs_file_t*)lfs->mlist;
     lfs->mlist = (struct lfs_mlist*)file;
 
-    if (tag == LFS_ERR_NOENT) {
 #ifdef LFS_READONLY
+    if (tag == LFS_ERR_NOENT) {
         err = LFS_ERR_NOENT;
         goto cleanup;
 #else
+    if (tag == LFS_ERR_NOENT) {
         if (!(flags & LFS_O_CREAT)) {
             err = LFS_ERR_NOENT;
             goto cleanup;
@@ -2871,7 +2872,7 @@ lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
             (void*)lfs, (void*)file, buffer, size);
     LFS_ASSERT(file->flags & LFS_F_OPENED);
 #ifdef LFS_READONLY
-    /* always LFS_O_RDONLY */
+    // always LFS_O_RDONLY
 #else
     LFS_ASSERT((file->flags & 3) != LFS_O_WRONLY);
 #endif
@@ -3217,12 +3218,10 @@ lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file) {
         LFS_TRACE("lfs_file_size -> %"PRId32,
                 lfs_max(file->pos, file->ctz.size));
         return lfs_max(file->pos, file->ctz.size);
-    } else
-#endif
-    {
-        LFS_TRACE("lfs_file_size -> %"PRId32, file->ctz.size);
-        return file->ctz.size;
     }
+#endif
+    LFS_TRACE("lfs_file_size -> %"PRId32, file->ctz.size);
+    return file->ctz.size;
 }
 
 

--- a/lfs.c
+++ b/lfs.c
@@ -169,7 +169,7 @@ static int lfs_bd_flush(lfs_t *lfs,
 
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_bd_sync(lfs_t *lfs,
@@ -185,7 +185,7 @@ static int lfs_bd_sync(lfs_t *lfs,
     LFS_ASSERT(err <= 0);
     return err;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_bd_prog(lfs_t *lfs,
@@ -233,7 +233,7 @@ static int lfs_bd_prog(lfs_t *lfs,
 
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_bd_erase(lfs_t *lfs, lfs_block_t block) {
@@ -242,7 +242,7 @@ static int lfs_bd_erase(lfs_t *lfs, lfs_block_t block) {
     LFS_ASSERT(err <= 0);
     return err;
 }
-#endif
+#endif /* LFS_READONLY */
 
 
 /// Small type-level utilities ///
@@ -401,7 +401,7 @@ static void lfs_ctz_tole32(struct lfs_ctz *ctz) {
     ctz->head = lfs_tole32(ctz->head);
     ctz->size = lfs_tole32(ctz->size);
 }
-#endif
+#endif /* LFS_READONLY */
 
 static inline void lfs_superblock_fromle32(lfs_superblock_t *superblock) {
     superblock->version     = lfs_fromle32(superblock->version);
@@ -440,18 +440,18 @@ static lfs_stag_t lfs_fs_parent(lfs_t *lfs, const lfs_block_t dir[2],
         lfs_mdir_t *parent);
 static int lfs_fs_relocate(lfs_t *lfs,
         const lfs_block_t oldpair[2], lfs_block_t newpair[2]);
-#endif
+#endif /* LFS_READONLY */
 int lfs_fs_traverseraw(lfs_t *lfs,
         int (*cb)(void *data, lfs_block_t block), void *data,
         bool includeorphans);
 #ifndef LFS_READONLY
 static int lfs_fs_forceconsistency(lfs_t *lfs);
-#endif
+#endif /* LFS_READONLY */
 static int lfs_deinit(lfs_t *lfs);
 #ifdef LFS_MIGRATE
 static int lfs1_traverse(lfs_t *lfs,
         int (*cb)(void*, lfs_block_t), void *data);
-#endif
+#endif /* LFS_MIGRATE */
 
 /// Block allocator ///
 #ifndef LFS_READONLY
@@ -466,7 +466,7 @@ static int lfs_alloc_lookahead(void *p, lfs_block_t block) {
 
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 static void lfs_alloc_ack(lfs_t *lfs) {
     lfs->free.ack = lfs->cfg->block_count;
@@ -527,7 +527,7 @@ static int lfs_alloc(lfs_t *lfs, lfs_block_t *block) {
         }
     }
 }
-#endif
+#endif /* LFS_READONLY */
 
 /// Metadata pair and directory operations ///
 static lfs_stag_t lfs_dir_getslice(lfs_t *lfs, const lfs_mdir_t *dir,
@@ -688,7 +688,7 @@ static int lfs_dir_traverse_filter(void *p,
 
     return false;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_dir_traverse(lfs_t *lfs,
@@ -784,7 +784,7 @@ static int lfs_dir_traverse(lfs_t *lfs,
         }
     }
 }
-#endif
+#endif /* LFS_READONLY */
 
 static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
         lfs_mdir_t *dir, const lfs_block_t pair[2],
@@ -1237,7 +1237,7 @@ static int lfs_dir_commitprog(lfs_t *lfs, struct lfs_commit *commit,
     commit->off += size;
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_dir_commitattr(lfs_t *lfs, struct lfs_commit *commit,
@@ -1284,7 +1284,7 @@ static int lfs_dir_commitattr(lfs_t *lfs, struct lfs_commit *commit,
     commit->ptag = tag & 0x7fffffff;
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_dir_commitcrc(lfs_t *lfs, struct lfs_commit *commit) {
@@ -1379,7 +1379,7 @@ static int lfs_dir_commitcrc(lfs_t *lfs, struct lfs_commit *commit) {
 
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_dir_alloc(lfs_t *lfs, lfs_mdir_t *dir) {
@@ -1419,7 +1419,7 @@ static int lfs_dir_alloc(lfs_t *lfs, lfs_mdir_t *dir) {
     // don't write out yet, let caller take care of that
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_dir_drop(lfs_t *lfs, lfs_mdir_t *dir, lfs_mdir_t *tail) {
@@ -1440,7 +1440,7 @@ static int lfs_dir_drop(lfs_t *lfs, lfs_mdir_t *dir, lfs_mdir_t *tail) {
 
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_dir_split(lfs_t *lfs,
@@ -1475,7 +1475,7 @@ static int lfs_dir_split(lfs_t *lfs,
 
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_dir_commit_size(void *p, lfs_tag_t tag, const void *buffer) {
@@ -1485,21 +1485,21 @@ static int lfs_dir_commit_size(void *p, lfs_tag_t tag, const void *buffer) {
     *size += lfs_tag_dsize(tag);
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 struct lfs_dir_commit_commit {
     lfs_t *lfs;
     struct lfs_commit *commit;
 };
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_dir_commit_commit(void *p, lfs_tag_t tag, const void *buffer) {
     struct lfs_dir_commit_commit *commit = p;
     return lfs_dir_commitattr(commit->lfs, commit->commit, tag, buffer);
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_dir_compact(lfs_t *lfs,
@@ -1595,7 +1595,7 @@ static int lfs_dir_compact(lfs_t *lfs,
             // pointers if we relocate the head of a directory. On top of
             // this, relocations increase the overall complexity of
             // lfs_migration, which is already a delicate operation.
-#endif
+#endif /* LFS_MIGRATE */
         } else {
             // we're writing too much, time to relocate
             tired = true;
@@ -1756,7 +1756,7 @@ relocate:
 
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_dir_commit(lfs_t *lfs, lfs_mdir_t *dir,
@@ -1946,7 +1946,7 @@ compact:
 
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 
 /// Top level directory operations ///
@@ -2049,7 +2049,7 @@ int lfs_mkdir(lfs_t *lfs, const char *path) {
     LFS_TRACE("lfs_mkdir -> %d", 0);
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 int lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
     LFS_TRACE("lfs_dir_open(%p, %p, \"%s\")", (void*)lfs, (void*)dir, path);
@@ -2381,7 +2381,7 @@ relocate:
         lfs_cache_drop(lfs, pcache);
     }
 }
-#endif
+#endif /* LFS_READONLY */
 
 static int lfs_ctz_traverse(lfs_t *lfs,
         const lfs_cache_t *pcache, lfs_cache_t *rcache,
@@ -2447,7 +2447,7 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
             return err;
         }
     }
-#endif
+#endif /* LFS_READONLY */
 
     // setup simple file details
     int err;
@@ -2497,10 +2497,10 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
         }
 
         tag = LFS_MKTAG(LFS_TYPE_INLINESTRUCT, 0, 0);
-#endif
     } else if (flags & LFS_O_EXCL) {
         err = LFS_ERR_EXIST;
         goto cleanup;
+#endif /* LFS_READONLY */
     } else if (lfs_tag_type3(tag) != LFS_TYPE_REG) {
         err = LFS_ERR_ISDIR;
         goto cleanup;
@@ -2509,7 +2509,7 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
         // truncate if requested
         tag = LFS_MKTAG(LFS_TYPE_INLINESTRUCT, file->id, 0);
         file->flags |= LFS_F_DIRTY;
-#endif
+#endif /* LFS_READONLY */
     } else {
         // try to load what's on disk, if it's inlined we'll fix it later
         tag = lfs_dir_get(lfs, &file->m, LFS_MKTAG(0x700, 0x3ff, 0),
@@ -2523,7 +2523,12 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
 
     // fetch attrs
     for (unsigned i = 0; i < file->cfg->attr_count; i++) {
-        if ((file->flags & 3) != LFS_O_WRONLY) {
+#ifdef LFS_READONLY
+        /* always LFS_O_RDONLY */
+#else
+        if ((file->flags & 3) != LFS_O_WRONLY)
+#endif /* LFS_READONLY */
+        {
             lfs_stag_t res = lfs_dir_get(lfs, &file->m,
                     LFS_MKTAG(0x7ff, 0x3ff, 0),
                     LFS_MKTAG(LFS_TYPE_USERATTR + file->cfg->attrs[i].type,
@@ -2544,7 +2549,7 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
 
             file->flags |= LFS_F_DIRTY;
         }
-#endif
+#endif /* LFS_READONLY */
     }
 
     // allocate buffer if needed
@@ -2613,7 +2618,7 @@ int lfs_file_close(lfs_t *lfs, lfs_file_t *file) {
     int err = 0;
 #else
     int err = lfs_file_sync(lfs, file);
-#endif
+#endif /* LFS_READONLY */
 
     // remove from list of mdirs
     for (struct lfs_mlist **p = &lfs->mlist; *p; p = &(*p)->next) {
@@ -2705,7 +2710,7 @@ relocate:
         lfs_cache_drop(lfs, &lfs->pcache);
     }
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_file_outline(lfs_t *lfs, lfs_file_t *file) {
@@ -2719,7 +2724,7 @@ static int lfs_file_outline(lfs_t *lfs, lfs_file_t *file) {
     file->flags &= ~LFS_F_INLINE;
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_file_flush(lfs_t *lfs, lfs_file_t *file) {
@@ -2801,7 +2806,7 @@ relocate:
 
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
@@ -2861,14 +2866,18 @@ int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_sync -> %d", 0);
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
         void *buffer, lfs_size_t size) {
     LFS_TRACE("lfs_file_read(%p, %p, %p, %"PRIu32")",
             (void*)lfs, (void*)file, buffer, size);
     LFS_ASSERT(file->flags & LFS_F_OPENED);
+#ifdef LFS_READONLY
+    /* always LFS_O_RDONLY */
+#else
     LFS_ASSERT((file->flags & 3) != LFS_O_WRONLY);
+#endif /* LFS_READONLY */
 
     uint8_t *data = buffer;
     lfs_size_t nsize = size;
@@ -2882,7 +2891,7 @@ lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
             return err;
         }
     }
-#endif
+#endif /* LFS_READONLY */
 
     if (file->pos >= file->ctz.size) {
         // eof if past end
@@ -3076,7 +3085,7 @@ relocate:
     LFS_TRACE("lfs_file_write -> %"PRId32, size);
     return size;
 }
-#endif
+#endif /* LFS_READONLY */
 
 lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
         lfs_soff_t off, int whence) {
@@ -3091,7 +3100,7 @@ lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
         LFS_TRACE("lfs_file_seek -> %d", err);
         return err;
     }
-#endif
+#endif /* LFS_READONLY */
 
     // find new pos
     lfs_off_t npos = file->pos;
@@ -3179,7 +3188,7 @@ int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     LFS_TRACE("lfs_file_truncate -> %d", 0);
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 lfs_soff_t lfs_file_tell(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_tell(%p, %p)", (void*)lfs, (void*)file);
@@ -3212,7 +3221,7 @@ lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file) {
                 lfs_max(file->pos, file->ctz.size));
         return lfs_max(file->pos, file->ctz.size);
     } else
-#endif
+#endif /* LFS_READONLY */
     {
         LFS_TRACE("lfs_file_size -> %"PRId32, file->ctz.size);
         return file->ctz.size;
@@ -3317,7 +3326,7 @@ int lfs_remove(lfs_t *lfs, const char *path) {
     LFS_TRACE("lfs_remove -> %d", 0);
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
@@ -3464,7 +3473,7 @@ int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
     LFS_TRACE("lfs_rename -> %d", 0);
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path,
         uint8_t type, void *buffer, lfs_size_t size) {
@@ -3529,7 +3538,7 @@ static int lfs_commitattr(lfs_t *lfs, const char *path,
     return lfs_dir_commit(lfs, &cwd, LFS_MKATTRS(
             {LFS_MKTAG(LFS_TYPE_USERATTR + type, id, size), buffer}));
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 int lfs_setattr(lfs_t *lfs, const char *path,
@@ -3545,7 +3554,7 @@ int lfs_setattr(lfs_t *lfs, const char *path,
     LFS_TRACE("lfs_setattr -> %d", err);
     return err;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type) {
@@ -3554,7 +3563,7 @@ int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type) {
     LFS_TRACE("lfs_removeattr -> %d", err);
     return err;
 }
-#endif
+#endif /* LFS_READONLY */
 
 
 /// Filesystem operations ///
@@ -3656,7 +3665,7 @@ static int lfs_init(lfs_t *lfs, const struct lfs_config *cfg) {
     lfs->gdelta = (lfs_gstate_t){0};
 #ifdef LFS_MIGRATE
     lfs->lfs1 = NULL;
-#endif
+#endif /* LFS_MIGRATE */
 
     return 0;
 
@@ -3765,7 +3774,7 @@ cleanup:
     return err;
 
 }
-#endif
+#endif /* LFS_READONLY */
 
 int lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
     LFS_TRACE("lfs_mount(%p, %p {.context=%p, "
@@ -3937,7 +3946,7 @@ int lfs_fs_traverseraw(lfs_t *lfs,
         dir.tail[0] = lfs->root[0];
         dir.tail[1] = lfs->root[1];
     }
-#endif
+#endif /* LFS_MIGRATE */
 
     lfs_block_t cycle = 0;
     while (!lfs_pair_isnull(dir.tail)) {
@@ -4012,7 +4021,7 @@ int lfs_fs_traverseraw(lfs_t *lfs,
                 return err;
             }
         }
-#endif
+#endif /* LFS_READONLY */
     }
 
     return 0;
@@ -4053,14 +4062,14 @@ static int lfs_fs_pred(lfs_t *lfs,
 
     return LFS_ERR_NOENT;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 struct lfs_fs_parent_match {
     lfs_t *lfs;
     const lfs_block_t pair[2];
 };
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_fs_parent_match(void *data,
@@ -4081,7 +4090,7 @@ static int lfs_fs_parent_match(void *data,
     lfs_pair_fromle32(child);
     return (lfs_pair_cmp(child, find->pair) == 0) ? LFS_CMP_EQ : LFS_CMP_LT;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static lfs_stag_t lfs_fs_parent(lfs_t *lfs, const lfs_block_t pair[2],
@@ -4110,7 +4119,7 @@ static lfs_stag_t lfs_fs_parent(lfs_t *lfs, const lfs_block_t pair[2],
 
     return LFS_ERR_NOENT;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_fs_relocate(lfs_t *lfs,
@@ -4207,7 +4216,7 @@ static int lfs_fs_relocate(lfs_t *lfs,
 
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static void lfs_fs_preporphans(lfs_t *lfs, int8_t orphans) {
@@ -4216,7 +4225,7 @@ static void lfs_fs_preporphans(lfs_t *lfs, int8_t orphans) {
     lfs->gstate.tag = ((lfs->gstate.tag & ~LFS_MKTAG(0x800, 0, 0)) |
             ((uint32_t)lfs_gstate_hasorphans(&lfs->gstate) << 31));
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static void lfs_fs_prepmove(lfs_t *lfs,
@@ -4226,7 +4235,7 @@ static void lfs_fs_prepmove(lfs_t *lfs,
     lfs->gstate.pair[0] = (id != 0x3ff) ? pair[0] : 0;
     lfs->gstate.pair[1] = (id != 0x3ff) ? pair[1] : 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_fs_demove(lfs_t *lfs) {
@@ -4258,7 +4267,7 @@ static int lfs_fs_demove(lfs_t *lfs) {
 
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_fs_deorphan(lfs_t *lfs) {
@@ -4334,7 +4343,7 @@ static int lfs_fs_deorphan(lfs_t *lfs) {
     lfs_fs_preporphans(lfs, -lfs_gstate_getorphans(&lfs->gstate));
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 #ifndef LFS_READONLY
 static int lfs_fs_forceconsistency(lfs_t *lfs) {
@@ -4350,7 +4359,7 @@ static int lfs_fs_forceconsistency(lfs_t *lfs) {
 
     return 0;
 }
-#endif
+#endif /* LFS_READONLY */
 
 static int lfs_fs_size_count(void *p, lfs_block_t block) {
     (void)block;
@@ -5034,4 +5043,4 @@ cleanup:
     return err;
 }
 
-#endif
+#endif /* LFS_MIGRATE */

--- a/lfs.c
+++ b/lfs.c
@@ -2523,12 +2523,8 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
 
     // fetch attrs
     for (unsigned i = 0; i < file->cfg->attr_count; i++) {
-#ifdef LFS_READONLY
-        /* always LFS_O_RDONLY */
-#else
-        if ((file->flags & 3) != LFS_O_WRONLY)
-#endif
-        {
+        // if opened for read / read-write operations
+        if ((file->flags & LFS_O_RDONLY) == LFS_O_RDONLY) {
             lfs_stag_t res = lfs_dir_get(lfs, &file->m,
                     LFS_MKTAG(0x7ff, 0x3ff, 0),
                     LFS_MKTAG(LFS_TYPE_USERATTR + file->cfg->attrs[i].type,
@@ -2541,7 +2537,8 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
         }
 
 #ifndef LFS_READONLY
-        if ((file->flags & 3) != LFS_O_RDONLY) {
+        // if opened for write / read-write operations
+        if ((file->flags & LFS_O_WRONLY) == LFS_O_WRONLY) {
             if (file->cfg->attrs[i].size > lfs->attr_max) {
                 err = LFS_ERR_NOSPC;
                 goto cleanup;

--- a/lfs.h
+++ b/lfs.h
@@ -76,6 +76,7 @@ enum lfs_error {
     LFS_ERR_EXIST       = -17,  // Entry already exists
     LFS_ERR_NOTDIR      = -20,  // Entry is not a dir
     LFS_ERR_ISDIR       = -21,  // Entry is a dir
+    LFS_ERR_NOSYS       = -38,  // Function not implemened
     LFS_ERR_NOTEMPTY    = -39,  // Dir is not empty
     LFS_ERR_BADF        = -9,   // Bad file number
     LFS_ERR_FBIG        = -27,  // File too large

--- a/lfs.h
+++ b/lfs.h
@@ -138,7 +138,9 @@ enum lfs_open_flags {
     LFS_F_WRITING = 0x020000, // File has been written since last flush
 #endif
     LFS_F_READING = 0x040000, // File has been read since last flush
+#ifndef LFS_READONLY
     LFS_F_ERRED   = 0x080000, // An error occurred during write
+#endif
     LFS_F_INLINE  = 0x100000, // Currently inlined in directory entry
     LFS_F_OPENED  = 0x200000, // File has been opened
 };

--- a/lfs.h
+++ b/lfs.h
@@ -664,8 +664,8 @@ int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 //
 // Returns a negative error code on failure.
 int lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg);
-#endif /* LFS_MIGRATE */
-#endif /* LFS_READONLY */
+#endif
+#endif
 
 
 #ifdef __cplusplus

--- a/lfs.h
+++ b/lfs.h
@@ -401,6 +401,7 @@ typedef struct lfs {
 
 /// Filesystem functions ///
 
+#ifndef LFS_READONLY
 // Format a block device with the littlefs
 //
 // Requires a littlefs object and config struct. This clobbers the littlefs
@@ -408,7 +409,6 @@ typedef struct lfs {
 // be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
-#ifndef LFS_READONLY
 int lfs_format(lfs_t *lfs, const struct lfs_config *config);
 #endif
 
@@ -430,21 +430,21 @@ int lfs_unmount(lfs_t *lfs);
 
 /// General operations ///
 
+#ifndef LFS_READONLY
 // Removes a file or directory
 //
 // If removing a directory, the directory must be empty.
 // Returns a negative error code on failure.
-#ifndef LFS_READONLY
 int lfs_remove(lfs_t *lfs, const char *path);
 #endif
 
+#ifndef LFS_READONLY
 // Rename or move a file or directory
 //
 // If the destination exists, it must match the source in type.
 // If the destination is a directory, the directory must be empty.
 //
 // Returns a negative error code on failure.
-#ifndef LFS_READONLY
 int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath);
 #endif
 
@@ -469,6 +469,7 @@ int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info);
 lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path,
         uint8_t type, void *buffer, lfs_size_t size);
 
+#ifndef LFS_READONLY
 // Set custom attributes
 //
 // Custom attributes are uniquely identified by an 8-bit type and limited
@@ -476,17 +477,16 @@ lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path,
 // implicitly created.
 //
 // Returns a negative error code on failure.
-#ifndef LFS_READONLY
 int lfs_setattr(lfs_t *lfs, const char *path,
         uint8_t type, const void *buffer, lfs_size_t size);
 #endif
 
+#ifndef LFS_READONLY
 // Removes a custom attribute
 //
 // If an attribute is not found, nothing happens.
 //
 // Returns a negative error code on failure.
-#ifndef LFS_READONLY
 int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type);
 #endif
 
@@ -537,13 +537,13 @@ int lfs_file_sync(lfs_t *lfs, lfs_file_t *file);
 lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
         void *buffer, lfs_size_t size);
 
+#ifndef LFS_READONLY
 // Write data to file
 //
 // Takes a buffer and size indicating the data to write. The file will not
 // actually be updated on the storage until either sync or close is called.
 //
 // Returns the number of bytes written, or a negative error code on failure.
-#ifndef LFS_READONLY
 lfs_ssize_t lfs_file_write(lfs_t *lfs, lfs_file_t *file,
         const void *buffer, lfs_size_t size);
 #endif
@@ -555,10 +555,10 @@ lfs_ssize_t lfs_file_write(lfs_t *lfs, lfs_file_t *file,
 lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
         lfs_soff_t off, int whence);
 
+#ifndef LFS_READONLY
 // Truncates the size of the file to the specified size
 //
 // Returns a negative error code on failure.
-#ifndef LFS_READONLY
 int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
 #endif
 
@@ -583,10 +583,10 @@ lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file);
 
 /// Directory operations ///
 
+#ifndef LFS_READONLY
 // Create a directory
 //
 // Returns a negative error code on failure.
-#ifndef LFS_READONLY
 int lfs_mkdir(lfs_t *lfs, const char *path);
 #endif
 

--- a/lfs.h
+++ b/lfs.h
@@ -76,7 +76,6 @@ enum lfs_error {
     LFS_ERR_EXIST       = -17,  // Entry already exists
     LFS_ERR_NOTDIR      = -20,  // Entry is not a dir
     LFS_ERR_ISDIR       = -21,  // Entry is a dir
-    LFS_ERR_ROFS        = -30,  // Read-only file system
     LFS_ERR_NOTEMPTY    = -39,  // Dir is not empty
     LFS_ERR_BADF        = -9,   // Bad file number
     LFS_ERR_FBIG        = -27,  // File too large

--- a/lfs.h
+++ b/lfs.h
@@ -133,10 +133,12 @@ enum lfs_open_flags {
 #endif
 
     // internally used flags
+#ifndef LFS_READONLY
     LFS_F_DIRTY   = 0x010000, // File does not match storage
     LFS_F_WRITING = 0x020000, // File has been written since last flush
+#endif
     LFS_F_READING = 0x040000, // File has been read since last flush
-    LFS_F_ERRED   = 0x080000, // An error occured during write
+    LFS_F_ERRED   = 0x080000, // An error occurred during write
     LFS_F_INLINE  = 0x100000, // Currently inlined in directory entry
     LFS_F_OPENED  = 0x200000, // File has been opened
 };

--- a/lfs.h
+++ b/lfs.h
@@ -123,12 +123,14 @@ enum lfs_type {
 enum lfs_open_flags {
     // open flags
     LFS_O_RDONLY = 1,         // Open a file as read only
+#ifndef LFS_READONLY
     LFS_O_WRONLY = 2,         // Open a file as write only
     LFS_O_RDWR   = 3,         // Open a file as read and write
     LFS_O_CREAT  = 0x0100,    // Create a file if it does not exist
     LFS_O_EXCL   = 0x0200,    // Fail if a file already exists
     LFS_O_TRUNC  = 0x0400,    // Truncate the existing file to zero size
     LFS_O_APPEND = 0x0800,    // Move to end of file on every write
+#endif
 
     // internally used flags
     LFS_F_DIRTY   = 0x010000, // File does not match storage
@@ -648,6 +650,7 @@ lfs_ssize_t lfs_fs_size(lfs_t *lfs);
 // Returns a negative error code on failure.
 int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 
+#ifndef LFS_READONLY
 #ifdef LFS_MIGRATE
 // Attempts to migrate a previous version of littlefs
 //
@@ -661,7 +664,8 @@ int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 //
 // Returns a negative error code on failure.
 int lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg);
-#endif
+#endif /* LFS_MIGRATE */
+#endif /* LFS_READONLY */
 
 
 #ifdef __cplusplus

--- a/lfs.h
+++ b/lfs.h
@@ -76,7 +76,7 @@ enum lfs_error {
     LFS_ERR_EXIST       = -17,  // Entry already exists
     LFS_ERR_NOTDIR      = -20,  // Entry is not a dir
     LFS_ERR_ISDIR       = -21,  // Entry is a dir
-    LFS_ERR_NOSYS       = -38,  // Function not implemened
+    LFS_ERR_ROFS        = -30,  // Read-only file system
     LFS_ERR_NOTEMPTY    = -39,  // Dir is not empty
     LFS_ERR_BADF        = -9,   // Bad file number
     LFS_ERR_FBIG        = -27,  // File too large
@@ -407,7 +407,9 @@ typedef struct lfs {
 // be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
+#ifndef LFS_READONLY
 int lfs_format(lfs_t *lfs, const struct lfs_config *config);
+#endif
 
 // Mounts a littlefs
 //
@@ -431,7 +433,9 @@ int lfs_unmount(lfs_t *lfs);
 //
 // If removing a directory, the directory must be empty.
 // Returns a negative error code on failure.
+#ifndef LFS_READONLY
 int lfs_remove(lfs_t *lfs, const char *path);
+#endif
 
 // Rename or move a file or directory
 //
@@ -439,7 +443,9 @@ int lfs_remove(lfs_t *lfs, const char *path);
 // If the destination is a directory, the directory must be empty.
 //
 // Returns a negative error code on failure.
+#ifndef LFS_READONLY
 int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath);
+#endif
 
 // Find info about a file or directory
 //
@@ -469,15 +475,19 @@ lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path,
 // implicitly created.
 //
 // Returns a negative error code on failure.
+#ifndef LFS_READONLY
 int lfs_setattr(lfs_t *lfs, const char *path,
         uint8_t type, const void *buffer, lfs_size_t size);
+#endif
 
 // Removes a custom attribute
 //
 // If an attribute is not found, nothing happens.
 //
 // Returns a negative error code on failure.
+#ifndef LFS_READONLY
 int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type);
+#endif
 
 
 /// File operations ///
@@ -532,8 +542,10 @@ lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
 // actually be updated on the storage until either sync or close is called.
 //
 // Returns the number of bytes written, or a negative error code on failure.
+#ifndef LFS_READONLY
 lfs_ssize_t lfs_file_write(lfs_t *lfs, lfs_file_t *file,
         const void *buffer, lfs_size_t size);
+#endif
 
 // Change the position of the file
 //
@@ -545,7 +557,9 @@ lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
 // Truncates the size of the file to the specified size
 //
 // Returns a negative error code on failure.
+#ifndef LFS_READONLY
 int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
+#endif
 
 // Return the position of the file
 //
@@ -571,7 +585,9 @@ lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file);
 // Create a directory
 //
 // Returns a negative error code on failure.
+#ifndef LFS_READONLY
 int lfs_mkdir(lfs_t *lfs, const char *path);
+#endif
 
 // Open a directory
 //


### PR DESCRIPTION
This PR tries to solve #162 , by providing an `LFS_READONLY` define.

LittleFS seems to be preferred over SPIFFS in many places and projects right now.
However, for my bootloader / firmware upgrade use-case, the code size matters a lot.
A bootloader could do with a read-only version of the file system, which should be a lot smaller in size.

With SPIFFS I am able to get a read-only version without caching compiled to around 3 KB (compiled for Cortex-M0),
while the read-write version with caching weighs in at around 13 KB, which is comparable to LittleFS.

By defining out a bunch of write-related functionality, I was able to reduce the read-only version of LittleFS to around 5 KB for that same Cortex-M0 target, which seems acceptable for bootloader use.

I have separately `#ifdef`'ed every function that is only needed for writing functionality.
However, I'm not sure if this is the preferred way, of if you'd rather have a single `#ifdef` around the whole lump of code.

Let me know if I can do anything to improve this PR.

Cheers and thanks for the awesome project! :+1: 