### PR TITLE
Fix several wear-leveling issues found in lfs_alloc_reset

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -459,7 +459,7 @@ static void lfs_alloc_ack(lfs_t *lfs) {
 // Invalidate the lookahead buffer. This is done during mounting and
 // failed traversals
 static void lfs_alloc_reset(lfs_t *lfs) {
-    lfs->free.off = lfs->seed % lfs->cfg->block_size;
+    lfs->free.off = lfs->seed % lfs->cfg->block_count;
     lfs->free.size = 0;
     lfs->free.i = 0;
     lfs_alloc_ack(lfs);

--- a/lfs.c
+++ b/lfs.c
@@ -872,8 +872,10 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
                 ptag ^= (lfs_tag_t)(lfs_tag_chunk(tag) & 1U) << 31;
 
                 // toss our crc into the filesystem seed for
-                // pseudorandom numbers
-                lfs->seed ^= crc;
+                // pseudorandom numbers, note we use another crc here
+                // as a collection function because it is sufficiently
+                // random and convenient
+                lfs->seed = lfs_crc(lfs->seed, &crc, sizeof(crc));
 
                 // update with what's found so far
                 besttag = tempbesttag;

--- a/scripts/readtree.py
+++ b/scripts/readtree.py
@@ -106,7 +106,7 @@ def main(args):
             struct.unpack('<HH', superblock[1].data[0:4].ljust(4, b'\xff'))))
     print("%-47s%s" % ("littlefs v%s.%s" % version,
         "data (truncated, if it fits)"
-        if not any([args.no_truncate, args.tags, args.log, args.all]) else ""))
+        if not any([args.no_truncate, args.log, args.all]) else ""))
 
     # print gstate
     print("gstate 0x%s" % ''.join('%02x' % c for c in gstate))


### PR DESCRIPTION
- Fixed incorrect modulus in lfs_alloc_reset

   Modulus of the offset by block_size was clearly a typo, and should be block_count. Interesting to note that later moduluses during alloc calculations prevents this from breaking anything, but as gtaska notes it could skew the wear-leveling distribution.

- Removed unnecessary randomization of offsets in lfs_alloc_reset

  On first read, randomizing the allocators offset may seem appropriate for lfs_alloc_reset. However, it ends up using the filesystem-fed pseudorandom seed in situations it wasn't designed for.

  As noted by gtaska, the combination of using xors for feeding the seed and multiple traverses of the same CRCs can cause the seed to flip to zeros with concerning frequency.

  Removed the randomization from lfs_alloc_reset, leaving it in only lfs_mount.

- Switched to CRC as seed collection function instead of xor

  As noted by gtaska, we are sitting on a better hash-combining function than xor: CRC. Previous issues with xor were solvable, but relying on xor for this isn't really worth the risk when we already have a CRC function readily available.

  To quote a study found by gtaska:
  https://michiel.buddingh.eu/distribution-of-hash-values
  > CRC32 seems to score really well, but its graph is skewed by the results of Dataset 5 (binary numbers), which may or may not be too synthetic to be considered a fair benchmark. But even if you substract the results from that test, it does not fare significantly worse than other, cryptographic hash functions.

Should fix https://github.com/littlefs-project/littlefs/issues/484
Related discussion https://github.com/littlefs-project/littlefs/issues/488
Found by @guiserle and @gtaska