### PR TITLE
Fix allocation-eviction issue when erase state is multiple of block_cycles+1

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -1375,11 +1375,11 @@ static int lfs_dir_alloc(lfs_t *lfs, lfs_mdir_t *dir) {
         return err;
     }
 
-    // make sure we don't immediately evict, see lfs_dir_compact for why
-    // this check is so complicated
-    if (lfs->cfg->block_cycles > 0 &&
-            (dir->rev + 1) % ((lfs->cfg->block_cycles+1)|1) == 0) {
-        dir->rev += 1;
+    // to make sure we don't immediately evict, align the new revision count
+    // to our block_cycles modulus, see lfs_dir_compact for why our modulus
+    // is tweaked this way
+    if (lfs->cfg->block_cycles > 0) {
+        dir->rev = lfs_alignup(dir->rev, ((lfs->cfg->block_cycles+1)|1));
     }
 
     // set defaults

--- a/lfs.c
+++ b/lfs.c
@@ -1375,8 +1375,12 @@ static int lfs_dir_alloc(lfs_t *lfs, lfs_mdir_t *dir) {
         return err;
     }
 
-    // make sure we don't immediately evict
-    dir->rev += dir->rev & 1;
+    // make sure we don't immediately evict, see lfs_dir_compact for why
+    // this check is so complicated
+    if (lfs->cfg->block_cycles > 0 &&
+            (dir->rev + 1) % ((lfs->cfg->block_cycles+1)|1) == 0) {
+        dir->rev += 1;
+    }
 
     // set defaults
     dir->off = sizeof(dir->rev);


### PR DESCRIPTION
See https://github.com/littlefs-project/littlefs/issues/489 for more information.

This rather interesting corner-case arises in lfs_dir_alloc anytime the uninitialized revision count happens to be a multiple of block_cycles+1.

For example, the source of the bug found by tim-nordell-nimbelink:

```
rev = 2742492087
block_cycles = 100

2742492087 % (100+1) = 0
```

The reason for this weird block_cycles+1 case is due to a fix for a previous bug in fe957de. To avoid aliasing, which would cause metadata pairs to wear unevenly, block_cycles incremented to the next odd number.

Normally, littlefs tweaks the revision count of blocks during lfs_dir_alloc in order to make sure evictions can't happen on the first compact. Otherwise, higher-level logic such as lfs_format would break.

However, this wasn't updated with the aliasing fix in fe957de, so lfs_dir_alloc was only rounding the revision count to the nearest even number.

The current fix is to ~change the logic in lfs_dir_alloc to explicitly check for the eviction condition and increment if eviction would occur.~ Align to the nearest multiple of the eviction condition (see https://github.com/littlefs-project/littlefs/issues/369)

Should help https://github.com/littlefs-project/littlefs/issues/489
Related https://github.com/littlefs-project/littlefs/issues/369
Found by @tim-nordell-nimbelink