### PR TITLE
Moved sanity check in lfs_format after compaction

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -3616,16 +3616,16 @@ static int lfs_rawformat(lfs_t *lfs, const struct lfs_config *cfg) {
             goto cleanup;
         }
 
-        // sanity check that fetch works
-        err = lfs_dir_fetch(lfs, &root, (const lfs_block_t[2]){0, 1});
-        if (err) {
-            goto cleanup;
-        }
-
         // force compaction to prevent accidentally mounting any
         // older version of littlefs that may live on disk
         root.erased = false;
         err = lfs_dir_commit(lfs, &root, NULL, 0);
+        if (err) {
+            goto cleanup;
+        }
+
+        // sanity check that fetch works
+        err = lfs_dir_fetch(lfs, &root, (const lfs_block_t[2]){0, 1});
         if (err) {
             goto cleanup;
         }


### PR DESCRIPTION
After a bit of tweaking in #193 to write out all superblocks during lfs_format, additional writes were added after the sanity checking normally done at the end.

This turned out to be a problem when porting littlefs, as it makes it easy for addressing issues to not get caught during lfs_format.

Helps https://github.com/littlefs-project/littlefs/issues/378
Found by @marekr, @tristanclare94, and @mjs513