### PR TITLE
Add cross-file syncing between multiple open files, introduce LFS_O_SNAPSHOT

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -2527,6 +2527,7 @@ static int lfs_file_rawopencfg(lfs_t *lfs, lfs_file_t *file,
 #ifndef LFS_READONLY
     } else if (flags & LFS_O_TRUNC) {
         // truncate if requested
+        // always mark dirty in case we have custom attributes
         tag = LFS_MKTAG(LFS_TYPE_INLINESTRUCT, file->id, 0);
         file->flags |= LFS_F_DIRTY;
 #endif
@@ -2878,7 +2879,7 @@ static int lfs_file_rawsync(lfs_t *lfs, lfs_file_t *file) {
                     }
                 }
 
-                file->flags &= ~(LFS_F_DIRTY | LFS_F_WRITING | LFS_F_READING);
+                f->flags &= ~(LFS_F_DIRTY | LFS_F_WRITING | LFS_F_READING);
             }
         }
 

--- a/lfs.c
+++ b/lfs.c
@@ -2506,11 +2506,12 @@ static int lfs_file_rawopencfg(lfs_t *lfs, lfs_file_t *file,
         }
 
         // get next slot and create entry to remember name
-        // TODO commit with attrs?
         err = lfs_dir_commit(lfs, &file->m, LFS_MKATTRS(
                 {LFS_MKTAG(LFS_TYPE_CREATE, file->id, 0), NULL},
                 {LFS_MKTAG(LFS_TYPE_REG, file->id, nlen), path},
-                {LFS_MKTAG(LFS_TYPE_INLINESTRUCT, file->id, 0), NULL}));
+                {LFS_MKTAG(LFS_TYPE_INLINESTRUCT, file->id, 0), NULL},
+                {LFS_MKTAG(LFS_FROM_USERATTRS, file->id,
+                    file->cfg->attr_count), file->cfg->attrs}));
         if (err) {
             err = LFS_ERR_NAMETOOLONG;
             goto cleanup;
@@ -2563,9 +2564,6 @@ static int lfs_file_rawopencfg(lfs_t *lfs, lfs_file_t *file,
                 err = LFS_ERR_NOSPC;
                 goto cleanup;
             }
-
-            // TODO remove this?
-            file->flags |= LFS_F_DIRTY;
         }
 #endif
     }

--- a/lfs.h
+++ b/lfs.h
@@ -300,10 +300,9 @@ struct lfs_file_config {
     // write occurs atomically with update to the file's contents.
     //
     // Custom attributes are uniquely identified by an 8-bit type and limited
-    // to LFS_ATTR_MAX bytes. When read, if the stored attribute is smaller
-    // than the buffer, it will be padded with zeros. If the stored attribute
-    // is larger, then it will be silently truncated. If the attribute is not
-    // found, it will be created implicitly.
+    // to LFS_ATTR_MAX bytes. If the stored attribute is larger than the
+    // provided buffer, it will be silently truncated. If no attribute is
+    // found, and the file is open for writing, it will be created implicitly.
     struct lfs_attr *attrs;
 
     // Number of custom attributes in the list
@@ -471,10 +470,9 @@ int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info);
 // Get a custom attribute
 //
 // Custom attributes are uniquely identified by an 8-bit type and limited
-// to LFS_ATTR_MAX bytes. When read, if the stored attribute is smaller than
-// the buffer, it will be padded with zeros. If the stored attribute is larger,
-// then it will be silently truncated. If no attribute is found, the error
-// LFS_ERR_NOATTR is returned and the buffer is filled with zeros.
+// to LFS_ATTR_MAX bytes. If the stored attribute is larger than the
+// provided buffer, it will be silently truncated. If no attribute is found,
+// the error LFS_ERR_NOATTR is returned and the buffer is filled with zeros.
 //
 // Returns the size of the attribute, or a negative error code on failure.
 // Note, the returned size is the size of the attribute on disk, irrespective

--- a/lfs.h
+++ b/lfs.h
@@ -294,10 +294,10 @@ struct lfs_file_config {
     void *buffer;
 
     // Optional list of custom attributes related to the file. If the file
-    // is opened with read access, these attributes will be read from disk
-    // during the open call. If the file is opened with write access, the
-    // attributes will be written to disk every file sync or close. This
-    // write occurs atomically with update to the file's contents.
+    // is opened for reading, these attributes will be read from disk during
+    // open. If the file is open for writing, these attribute will be atomically
+    // written to disk when the file is written to disk. Note that these
+    // attributes are not written unless the file is modified.
     //
     // Custom attributes are uniquely identified by an 8-bit type and limited
     // to LFS_ATTR_MAX bytes. If the stored attribute is larger than the

--- a/lfs.h
+++ b/lfs.h
@@ -123,26 +123,30 @@ enum lfs_type {
 // File open flags
 enum lfs_open_flags {
     // open flags
-    LFS_O_RDONLY = 1,         // Open a file as read only
+    LFS_O_RDONLY    = 1,        // Open a file as read only
 #ifndef LFS_READONLY
-    LFS_O_WRONLY = 2,         // Open a file as write only
-    LFS_O_RDWR   = 3,         // Open a file as read and write
-    LFS_O_CREAT  = 0x0100,    // Create a file if it does not exist
-    LFS_O_EXCL   = 0x0200,    // Fail if a file already exists
-    LFS_O_TRUNC  = 0x0400,    // Truncate the existing file to zero size
-    LFS_O_APPEND = 0x0800,    // Move to end of file on every write
+    LFS_O_WRONLY    = 2,        // Open a file as write only
+    LFS_O_RDWR      = 3,        // Open a file as read and write
+#endif
+
+#ifndef LFS_READONLY
+    LFS_O_CREAT     = 0x0100,   // Create a file if it does not exist
+    LFS_O_EXCL      = 0x0200,   // Fail if a file already exists
+    LFS_O_TRUNC     = 0x0400,   // Truncate the existing file to zero size
+    LFS_O_APPEND    = 0x0800,   // Move to end of file on every write
+    LFS_O_SNAPSHOT  = 0x1000,   // Open a temporary snapshot, ignore changes
 #endif
 
     // internally used flags
 #ifndef LFS_READONLY
-    LFS_F_DIRTY   = 0x010000, // File does not match storage
-    LFS_F_WRITING = 0x020000, // File has been written since last flush
+    LFS_F_DIRTY     = 0x010000, // File does not match storage
 #endif
-    LFS_F_READING = 0x040000, // File has been read since last flush
+    LFS_F_READING   = 0x020000, // File has been read since last flush
 #ifndef LFS_READONLY
-    LFS_F_ERRED   = 0x080000, // An error occurred during write
+    LFS_F_WRITING   = 0x040000, // File has been written since last flush
+    LFS_F_ZOMBIE    = 0x080000, // An error occurred during write
 #endif
-    LFS_F_INLINE  = 0x100000, // Currently inlined in directory entry
+    LFS_F_INLINE    = 0x100000, // Currently inlined in directory entry
 };
 
 // File seek flags

--- a/tests/test_attrs.toml
+++ b/tests/test_attrs.toml
@@ -25,7 +25,6 @@ code = '''
     lfs_getattr(&lfs, "hello", 'B', buffer+4,  6) => 0;
     lfs_getattr(&lfs, "hello", 'C', buffer+10, 5) => 5;
     assert(memcmp(buffer,    "aaaa",         4) == 0);
-    assert(memcmp(buffer+4,  "\0\0\0\0\0\0", 6) == 0);
     assert(memcmp(buffer+10, "ccccc",        5) == 0);
 
     lfs_removeattr(&lfs, "hello", 'B') => 0;
@@ -33,7 +32,6 @@ code = '''
     lfs_getattr(&lfs, "hello", 'B', buffer+4,  6) => LFS_ERR_NOATTR;
     lfs_getattr(&lfs, "hello", 'C', buffer+10, 5) => 5;
     assert(memcmp(buffer,    "aaaa",         4) == 0);
-    assert(memcmp(buffer+4,  "\0\0\0\0\0\0", 6) == 0);
     assert(memcmp(buffer+10, "ccccc",        5) == 0);
 
     lfs_setattr(&lfs, "hello", 'B', "dddddd", 6) => 0;
@@ -48,9 +46,9 @@ code = '''
     lfs_getattr(&lfs, "hello", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "hello", 'B', buffer+4,  6) => 3;
     lfs_getattr(&lfs, "hello", 'C', buffer+10, 5) => 5;
-    assert(memcmp(buffer,    "aaaa",      4) == 0);
-    assert(memcmp(buffer+4,  "eee\0\0\0", 6) == 0);
-    assert(memcmp(buffer+10, "ccccc",     5) == 0);
+    assert(memcmp(buffer,    "aaaa",  4) == 0);
+    assert(memcmp(buffer+4,  "eee",   3) == 0);
+    assert(memcmp(buffer+10, "ccccc", 5) == 0);
 
     lfs_setattr(&lfs, "hello", 'A', buffer, LFS_ATTR_MAX+1) => LFS_ERR_NOSPC;
     lfs_setattr(&lfs, "hello", 'B', "fffffffff", 9) => 0;
@@ -102,17 +100,15 @@ code = '''
     lfs_getattr(&lfs, "/", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "/", 'B', buffer+4,  6) => 0;
     lfs_getattr(&lfs, "/", 'C', buffer+10, 5) => 5;
-    assert(memcmp(buffer,    "aaaa",         4) == 0);
-    assert(memcmp(buffer+4,  "\0\0\0\0\0\0", 6) == 0);
-    assert(memcmp(buffer+10, "ccccc",        5) == 0);
+    assert(memcmp(buffer,    "aaaa",  4) == 0);
+    assert(memcmp(buffer+10, "ccccc", 5) == 0);
 
     lfs_removeattr(&lfs, "/", 'B') => 0;
     lfs_getattr(&lfs, "/", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "/", 'B', buffer+4,  6) => LFS_ERR_NOATTR;
     lfs_getattr(&lfs, "/", 'C', buffer+10, 5) => 5;
-    assert(memcmp(buffer,    "aaaa",         4) == 0);
-    assert(memcmp(buffer+4,  "\0\0\0\0\0\0", 6) == 0);
-    assert(memcmp(buffer+10, "ccccc",        5) == 0);
+    assert(memcmp(buffer,    "aaaa",  4) == 0);
+    assert(memcmp(buffer+10, "ccccc", 5) == 0);
 
     lfs_setattr(&lfs, "/", 'B', "dddddd", 6) => 0;
     lfs_getattr(&lfs, "/", 'A', buffer,    4) => 4;
@@ -126,9 +122,9 @@ code = '''
     lfs_getattr(&lfs, "/", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "/", 'B', buffer+4,  6) => 3;
     lfs_getattr(&lfs, "/", 'C', buffer+10, 5) => 5;
-    assert(memcmp(buffer,    "aaaa",      4) == 0);
-    assert(memcmp(buffer+4,  "eee\0\0\0", 6) == 0);
-    assert(memcmp(buffer+10, "ccccc",     5) == 0);
+    assert(memcmp(buffer,    "aaaa",  4) == 0);
+    assert(memcmp(buffer+4,  "eee",   3) == 0);
+    assert(memcmp(buffer+10, "ccccc", 5) == 0);
 
     lfs_setattr(&lfs, "/", 'A', buffer, LFS_ATTR_MAX+1) => LFS_ERR_NOSPC;
     lfs_setattr(&lfs, "/", 'B', "fffffffff", 9) => 0;
@@ -193,9 +189,8 @@ code = '''
     attrs1[1].size = 6;
     lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_RDONLY, &cfg1) => 0;
     lfs_file_close(&lfs, &file) => 0;
-    assert(memcmp(buffer,    "aaaa",         4) == 0);
-    assert(memcmp(buffer+4,  "\0\0\0\0\0\0", 6) == 0);
-    assert(memcmp(buffer+10, "ccccc",        5) == 0);
+    assert(memcmp(buffer,    "aaaa",  4) == 0);
+    assert(memcmp(buffer+10, "ccccc", 5) == 0);
 
     attrs1[1].size = 6;
     lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_WRONLY, &cfg1) => 0;
@@ -219,9 +214,9 @@ code = '''
     attrs1[1].size = 6;
     lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_RDONLY, &cfg1) => 0;
     lfs_file_close(&lfs, &file) => 0;
-    assert(memcmp(buffer,    "aaaa",      4) == 0);
-    assert(memcmp(buffer+4,  "eee\0\0\0", 6) == 0);
-    assert(memcmp(buffer+10, "ccccc",     5) == 0);
+    assert(memcmp(buffer,    "aaaa",  4) == 0);
+    assert(memcmp(buffer+4,  "eee",   3) == 0);
+    assert(memcmp(buffer+10, "ccccc", 5) == 0);
 
     attrs1[0].size = LFS_ATTR_MAX+1;
     lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_WRONLY, &cfg1)
@@ -292,18 +287,16 @@ code = '''
     lfs_getattr(&lfs, "hello/hello", 'B', buffer,    9) => 9;
     lfs_getattr(&lfs, "hello/hello", 'C', buffer+9,  9) => 5;
     lfs_getattr(&lfs, "hello/hello", 'D', buffer+18, 9) => LFS_ERR_NOATTR;
-    assert(memcmp(buffer,    "fffffffff",          9) == 0);
-    assert(memcmp(buffer+9,  "ccccc\0\0\0\0",      9) == 0);
-    assert(memcmp(buffer+18, "\0\0\0\0\0\0\0\0\0", 9) == 0);
+    assert(memcmp(buffer,    "fffffffff", 9) == 0);
+    assert(memcmp(buffer+9,  "ccccc",     5) == 0);
 
     lfs_file_write(&lfs, &file, "hi", 2) => 2;
     lfs_file_sync(&lfs, &file) => 0;
     lfs_getattr(&lfs, "hello/hello", 'B', buffer,    9) => 4;
     lfs_getattr(&lfs, "hello/hello", 'C', buffer+9,  9) => 0;
     lfs_getattr(&lfs, "hello/hello", 'D', buffer+18, 9) => 4;
-    assert(memcmp(buffer,    "gggg\0\0\0\0\0",     9) == 0);
-    assert(memcmp(buffer+9,  "\0\0\0\0\0\0\0\0\0", 9) == 0);
-    assert(memcmp(buffer+18, "hhhh\0\0\0\0\0",     9) == 0);
+    assert(memcmp(buffer,    "gggg", 4) == 0);
+    assert(memcmp(buffer+18, "hhhh", 4) == 0);
 
     lfs_file_close(&lfs, &file) => 0;
     lfs_unmount(&lfs) => 0;

--- a/tests/test_attrs.toml
+++ b/tests/test_attrs.toml
@@ -219,8 +219,8 @@ code = '''
     assert(memcmp(buffer+10, "ccccc", 5) == 0);
 
     attrs1[0].size = LFS_ATTR_MAX+1;
-    lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_WRONLY, &cfg1)
-        => LFS_ERR_NOSPC;
+    lfs_file_opencfg(&lfs, &file, "hello/hello2",
+            LFS_O_WRONLY | LFS_O_CREAT, &cfg1) => LFS_ERR_NOSPC;
 
     struct lfs_attr attrs2[] = {
         {'A', buffer,    4},

--- a/tests/test_attrs.toml
+++ b/tests/test_attrs.toml
@@ -16,41 +16,41 @@ code = '''
     lfs_getattr(&lfs, "hello", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "hello", 'B', buffer+4,  6) => 6;
     lfs_getattr(&lfs, "hello", 'C', buffer+10, 5) => 5;
-    memcmp(buffer,    "aaaa",   4) => 0;
-    memcmp(buffer+4,  "bbbbbb", 6) => 0;
-    memcmp(buffer+10, "ccccc",  5) => 0;
+    assert(memcmp(buffer,    "aaaa",   4) == 0);
+    assert(memcmp(buffer+4,  "bbbbbb", 6) == 0);
+    assert(memcmp(buffer+10, "ccccc",  5) == 0);
 
     lfs_setattr(&lfs, "hello", 'B', "", 0) => 0;
     lfs_getattr(&lfs, "hello", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "hello", 'B', buffer+4,  6) => 0;
     lfs_getattr(&lfs, "hello", 'C', buffer+10, 5) => 5;
-    memcmp(buffer,    "aaaa",         4) => 0;
-    memcmp(buffer+4,  "\0\0\0\0\0\0", 6) => 0;
-    memcmp(buffer+10, "ccccc",        5) => 0;
+    assert(memcmp(buffer,    "aaaa",         4) == 0);
+    assert(memcmp(buffer+4,  "\0\0\0\0\0\0", 6) == 0);
+    assert(memcmp(buffer+10, "ccccc",        5) == 0);
 
     lfs_removeattr(&lfs, "hello", 'B') => 0;
     lfs_getattr(&lfs, "hello", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "hello", 'B', buffer+4,  6) => LFS_ERR_NOATTR;
     lfs_getattr(&lfs, "hello", 'C', buffer+10, 5) => 5;
-    memcmp(buffer,    "aaaa",         4) => 0;
-    memcmp(buffer+4,  "\0\0\0\0\0\0", 6) => 0;
-    memcmp(buffer+10, "ccccc",        5) => 0;
+    assert(memcmp(buffer,    "aaaa",         4) == 0);
+    assert(memcmp(buffer+4,  "\0\0\0\0\0\0", 6) == 0);
+    assert(memcmp(buffer+10, "ccccc",        5) == 0);
 
     lfs_setattr(&lfs, "hello", 'B', "dddddd", 6) => 0;
     lfs_getattr(&lfs, "hello", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "hello", 'B', buffer+4,  6) => 6;
     lfs_getattr(&lfs, "hello", 'C', buffer+10, 5) => 5;
-    memcmp(buffer,    "aaaa",   4) => 0;
-    memcmp(buffer+4,  "dddddd", 6) => 0;
-    memcmp(buffer+10, "ccccc",  5) => 0;
+    assert(memcmp(buffer,    "aaaa",   4) == 0);
+    assert(memcmp(buffer+4,  "dddddd", 6) == 0);
+    assert(memcmp(buffer+10, "ccccc",  5) == 0);
 
     lfs_setattr(&lfs, "hello", 'B', "eee", 3) => 0;
     lfs_getattr(&lfs, "hello", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "hello", 'B', buffer+4,  6) => 3;
     lfs_getattr(&lfs, "hello", 'C', buffer+10, 5) => 5;
-    memcmp(buffer,    "aaaa",      4) => 0;
-    memcmp(buffer+4,  "eee\0\0\0", 6) => 0;
-    memcmp(buffer+10, "ccccc",     5) => 0;
+    assert(memcmp(buffer,    "aaaa",      4) == 0);
+    assert(memcmp(buffer+4,  "eee\0\0\0", 6) == 0);
+    assert(memcmp(buffer+10, "ccccc",     5) == 0);
 
     lfs_setattr(&lfs, "hello", 'A', buffer, LFS_ATTR_MAX+1) => LFS_ERR_NOSPC;
     lfs_setattr(&lfs, "hello", 'B', "fffffffff", 9) => 0;
@@ -65,13 +65,13 @@ code = '''
     lfs_getattr(&lfs, "hello", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "hello", 'B', buffer+4,  9) => 9;
     lfs_getattr(&lfs, "hello", 'C', buffer+13, 5) => 5;
-    memcmp(buffer,    "aaaa",      4) => 0;
-    memcmp(buffer+4,  "fffffffff", 9) => 0;
-    memcmp(buffer+13, "ccccc",     5) => 0;
+    assert(memcmp(buffer,    "aaaa",      4) == 0);
+    assert(memcmp(buffer+4,  "fffffffff", 9) == 0);
+    assert(memcmp(buffer+13, "ccccc",     5) == 0);
 
     lfs_file_open(&lfs, &file, "hello/hello", LFS_O_RDONLY) => 0;
     lfs_file_read(&lfs, &file, buffer, sizeof(buffer)) => strlen("hello");
-    memcmp(buffer, "hello", strlen("hello")) => 0;
+    assert(memcmp(buffer, "hello", strlen("hello")) == 0);
     lfs_file_close(&lfs, &file);
     lfs_unmount(&lfs) => 0;
 '''
@@ -94,41 +94,41 @@ code = '''
     lfs_getattr(&lfs, "/", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "/", 'B', buffer+4,  6) => 6;
     lfs_getattr(&lfs, "/", 'C', buffer+10, 5) => 5;
-    memcmp(buffer,    "aaaa",   4) => 0;
-    memcmp(buffer+4,  "bbbbbb", 6) => 0;
-    memcmp(buffer+10, "ccccc",  5) => 0;
+    assert(memcmp(buffer,    "aaaa",   4) == 0);
+    assert(memcmp(buffer+4,  "bbbbbb", 6) == 0);
+    assert(memcmp(buffer+10, "ccccc",  5) == 0);
 
     lfs_setattr(&lfs, "/", 'B', "", 0) => 0;
     lfs_getattr(&lfs, "/", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "/", 'B', buffer+4,  6) => 0;
     lfs_getattr(&lfs, "/", 'C', buffer+10, 5) => 5;
-    memcmp(buffer,    "aaaa",         4) => 0;
-    memcmp(buffer+4,  "\0\0\0\0\0\0", 6) => 0;
-    memcmp(buffer+10, "ccccc",        5) => 0;
+    assert(memcmp(buffer,    "aaaa",         4) == 0);
+    assert(memcmp(buffer+4,  "\0\0\0\0\0\0", 6) == 0);
+    assert(memcmp(buffer+10, "ccccc",        5) == 0);
 
     lfs_removeattr(&lfs, "/", 'B') => 0;
     lfs_getattr(&lfs, "/", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "/", 'B', buffer+4,  6) => LFS_ERR_NOATTR;
     lfs_getattr(&lfs, "/", 'C', buffer+10, 5) => 5;
-    memcmp(buffer,    "aaaa",         4) => 0;
-    memcmp(buffer+4,  "\0\0\0\0\0\0", 6) => 0;
-    memcmp(buffer+10, "ccccc",        5) => 0;
+    assert(memcmp(buffer,    "aaaa",         4) == 0);
+    assert(memcmp(buffer+4,  "\0\0\0\0\0\0", 6) == 0);
+    assert(memcmp(buffer+10, "ccccc",        5) == 0);
 
     lfs_setattr(&lfs, "/", 'B', "dddddd", 6) => 0;
     lfs_getattr(&lfs, "/", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "/", 'B', buffer+4,  6) => 6;
     lfs_getattr(&lfs, "/", 'C', buffer+10, 5) => 5;
-    memcmp(buffer,    "aaaa",   4) => 0;
-    memcmp(buffer+4,  "dddddd", 6) => 0;
-    memcmp(buffer+10, "ccccc",  5) => 0;
+    assert(memcmp(buffer,    "aaaa",   4) == 0);
+    assert(memcmp(buffer+4,  "dddddd", 6) == 0);
+    assert(memcmp(buffer+10, "ccccc",  5) == 0);
 
     lfs_setattr(&lfs, "/", 'B', "eee", 3) => 0;
     lfs_getattr(&lfs, "/", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "/", 'B', buffer+4,  6) => 3;
     lfs_getattr(&lfs, "/", 'C', buffer+10, 5) => 5;
-    memcmp(buffer,    "aaaa",      4) => 0;
-    memcmp(buffer+4,  "eee\0\0\0", 6) => 0;
-    memcmp(buffer+10, "ccccc",     5) => 0;
+    assert(memcmp(buffer,    "aaaa",      4) == 0);
+    assert(memcmp(buffer+4,  "eee\0\0\0", 6) == 0);
+    assert(memcmp(buffer+10, "ccccc",     5) == 0);
 
     lfs_setattr(&lfs, "/", 'A', buffer, LFS_ATTR_MAX+1) => LFS_ERR_NOSPC;
     lfs_setattr(&lfs, "/", 'B', "fffffffff", 9) => 0;
@@ -142,13 +142,13 @@ code = '''
     lfs_getattr(&lfs, "/", 'A', buffer,    4) => 4;
     lfs_getattr(&lfs, "/", 'B', buffer+4,  9) => 9;
     lfs_getattr(&lfs, "/", 'C', buffer+13, 5) => 5;
-    memcmp(buffer,    "aaaa",      4) => 0;
-    memcmp(buffer+4,  "fffffffff", 9) => 0;
-    memcmp(buffer+13, "ccccc",     5) => 0;
+    assert(memcmp(buffer,    "aaaa",      4) == 0);
+    assert(memcmp(buffer+4,  "fffffffff", 9) == 0);
+    assert(memcmp(buffer+13, "ccccc",     5) == 0);
 
     lfs_file_open(&lfs, &file, "hello/hello", LFS_O_RDONLY) => 0;
     lfs_file_read(&lfs, &file, buffer, sizeof(buffer)) => strlen("hello");
-    memcmp(buffer, "hello", strlen("hello")) => 0;
+    assert(memcmp(buffer, "hello", strlen("hello")) == 0);
     lfs_file_close(&lfs, &file);
     lfs_unmount(&lfs) => 0;
 '''
@@ -176,48 +176,52 @@ code = '''
     memcpy(buffer,    "aaaa",   4);
     memcpy(buffer+4,  "bbbbbb", 6);
     memcpy(buffer+10, "ccccc",  5);
+    lfs_file_write(&lfs, &file, "hi", 2) => 2;
     lfs_file_close(&lfs, &file) => 0;
     memset(buffer, 0, 15);
     lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_RDONLY, &cfg1) => 0;
     lfs_file_close(&lfs, &file) => 0;
-    memcmp(buffer,    "aaaa",   4) => 0;
-    memcmp(buffer+4,  "bbbbbb", 6) => 0;
-    memcmp(buffer+10, "ccccc",  5) => 0;
+    assert(memcmp(buffer,    "aaaa",   4) == 0);
+    assert(memcmp(buffer+4,  "bbbbbb", 6) == 0);
+    assert(memcmp(buffer+10, "ccccc",  5) == 0);
 
     attrs1[1].size = 0;
     lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_WRONLY, &cfg1) => 0;
+    lfs_file_write(&lfs, &file, "hi", 2) => 2;
     lfs_file_close(&lfs, &file) => 0;
     memset(buffer, 0, 15);
     attrs1[1].size = 6;
     lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_RDONLY, &cfg1) => 0;
     lfs_file_close(&lfs, &file) => 0;
-    memcmp(buffer,    "aaaa",         4) => 0;
-    memcmp(buffer+4,  "\0\0\0\0\0\0", 6) => 0;
-    memcmp(buffer+10, "ccccc",        5) => 0;
+    assert(memcmp(buffer,    "aaaa",         4) == 0);
+    assert(memcmp(buffer+4,  "\0\0\0\0\0\0", 6) == 0);
+    assert(memcmp(buffer+10, "ccccc",        5) == 0);
 
     attrs1[1].size = 6;
     lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_WRONLY, &cfg1) => 0;
     memcpy(buffer+4,  "dddddd", 6);
+    lfs_file_write(&lfs, &file, "hi", 2) => 2;
     lfs_file_close(&lfs, &file) => 0;
     memset(buffer, 0, 15);
     attrs1[1].size = 6;
     lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_RDONLY, &cfg1) => 0;
     lfs_file_close(&lfs, &file) => 0;
-    memcmp(buffer,    "aaaa",   4) => 0;
-    memcmp(buffer+4,  "dddddd", 6) => 0;
-    memcmp(buffer+10, "ccccc",  5) => 0;
+    assert(memcmp(buffer,    "aaaa",   4) == 0);
+    assert(memcmp(buffer+4,  "dddddd", 6) == 0);
+    assert(memcmp(buffer+10, "ccccc",  5) == 0);
 
     attrs1[1].size = 3;
     lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_WRONLY, &cfg1) => 0;
     memcpy(buffer+4,  "eee", 3);
+    lfs_file_write(&lfs, &file, "hi", 2) => 2;
     lfs_file_close(&lfs, &file) => 0;
     memset(buffer, 0, 15);
     attrs1[1].size = 6;
     lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_RDONLY, &cfg1) => 0;
     lfs_file_close(&lfs, &file) => 0;
-    memcmp(buffer,    "aaaa",      4) => 0;
-    memcmp(buffer+4,  "eee\0\0\0", 6) => 0;
-    memcmp(buffer+10, "ccccc",     5) => 0;
+    assert(memcmp(buffer,    "aaaa",      4) == 0);
+    assert(memcmp(buffer+4,  "eee\0\0\0", 6) == 0);
+    assert(memcmp(buffer+10, "ccccc",     5) == 0);
 
     attrs1[0].size = LFS_ATTR_MAX+1;
     lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_WRONLY, &cfg1)
@@ -231,6 +235,7 @@ code = '''
     struct lfs_file_config cfg2 = {.attrs=attrs2, .attr_count=3};
     lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_RDWR, &cfg2) => 0;
     memcpy(buffer+4,  "fffffffff", 9);
+    lfs_file_write(&lfs, &file, "hi", 2) => 2;
     lfs_file_close(&lfs, &file) => 0;
     attrs1[0].size = 4;
     lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_RDONLY, &cfg1) => 0;
@@ -249,13 +254,13 @@ code = '''
 
     lfs_file_opencfg(&lfs, &file, "hello/hello", LFS_O_RDONLY, &cfg3) => 0;
     lfs_file_close(&lfs, &file) => 0;
-    memcmp(buffer,    "aaaa",      4) => 0;
-    memcmp(buffer+4,  "fffffffff", 9) => 0;
-    memcmp(buffer+13, "ccccc",     5) => 0;
+    assert(memcmp(buffer,    "aaaa",      4) == 0);
+    assert(memcmp(buffer+4,  "fffffffff", 9) == 0);
+    assert(memcmp(buffer+13, "ccccc",     5) == 0);
 
     lfs_file_open(&lfs, &file, "hello/hello", LFS_O_RDONLY) => 0;
     lfs_file_read(&lfs, &file, buffer, sizeof(buffer)) => strlen("hello");
-    memcmp(buffer, "hello", strlen("hello")) => 0;
+    assert(memcmp(buffer, "hillo", strlen("hello")) == 0);
     lfs_file_close(&lfs, &file);
     lfs_unmount(&lfs) => 0;
 '''
@@ -287,17 +292,18 @@ code = '''
     lfs_getattr(&lfs, "hello/hello", 'B', buffer,    9) => 9;
     lfs_getattr(&lfs, "hello/hello", 'C', buffer+9,  9) => 5;
     lfs_getattr(&lfs, "hello/hello", 'D', buffer+18, 9) => LFS_ERR_NOATTR;
-    memcmp(buffer,    "fffffffff",          9) => 0;
-    memcmp(buffer+9,  "ccccc\0\0\0\0",      9) => 0;
-    memcmp(buffer+18, "\0\0\0\0\0\0\0\0\0", 9) => 0;
+    assert(memcmp(buffer,    "fffffffff",          9) == 0);
+    assert(memcmp(buffer+9,  "ccccc\0\0\0\0",      9) == 0);
+    assert(memcmp(buffer+18, "\0\0\0\0\0\0\0\0\0", 9) == 0);
 
+    lfs_file_write(&lfs, &file, "hi", 2) => 2;
     lfs_file_sync(&lfs, &file) => 0;
     lfs_getattr(&lfs, "hello/hello", 'B', buffer,    9) => 4;
     lfs_getattr(&lfs, "hello/hello", 'C', buffer+9,  9) => 0;
     lfs_getattr(&lfs, "hello/hello", 'D', buffer+18, 9) => 4;
-    memcmp(buffer,    "gggg\0\0\0\0\0",     9) => 0;
-    memcmp(buffer+9,  "\0\0\0\0\0\0\0\0\0", 9) => 0;
-    memcmp(buffer+18, "hhhh\0\0\0\0\0",     9) => 0;
+    assert(memcmp(buffer,    "gggg\0\0\0\0\0",     9) == 0);
+    assert(memcmp(buffer+9,  "\0\0\0\0\0\0\0\0\0", 9) == 0);
+    assert(memcmp(buffer+18, "hhhh\0\0\0\0\0",     9) == 0);
 
     lfs_file_close(&lfs, &file) => 0;
     lfs_unmount(&lfs) => 0;

--- a/tests/test_interspersed.toml
+++ b/tests/test_interspersed.toml
@@ -504,3 +504,433 @@ code = '''
     }
     lfs_unmount(&lfs) => 0;
 '''
+
+[[case]] # simple snapshot for reading
+define.SIZE = [10, 100, 1000, 10000]
+code = '''
+    const char alphas[] = "abcdefghijklmnopqrstuvwxyz";
+    const char nums[] = "0123456789";
+    lfs_format(&lfs, &cfg) => 0;
+    lfs_mount(&lfs, &cfg) => 0;
+    const struct lfs_file_config filecfg = {
+        .attr_count = 1,
+        .attrs = (struct lfs_attr[]){
+            {'A', "abcd", 4},
+        },
+    };
+    lfs_file_opencfg(&lfs, &file, "open_me",
+            LFS_O_CREAT | LFS_O_WRONLY, &filecfg) => 0;
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_write(&lfs, &file, &alphas[j % 26], 1) => 1;
+    }
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_unmount(&lfs) => 0;
+
+    // open reader/writer/snapshot
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_file_t reader;
+    const struct lfs_file_config readercfg = {
+        .attr_count = 1,
+        .attrs = (struct lfs_attr[]){
+            {'A', &(uint8_t[4]){0}, 4}
+        },
+    };
+    lfs_file_t writer;
+    const struct lfs_file_config writercfg = {
+        .attr_count = 1,
+        .attrs = (struct lfs_attr[]){
+            {'A', &(uint8_t[4]){0}, 4}
+        },
+    };
+    lfs_file_t snapshot;
+    const struct lfs_file_config snapshotcfg = {
+        .attr_count = 1,
+        .attrs = (struct lfs_attr[]){
+            {'A', &(uint8_t[4]){0}, 4}
+        },
+    };
+    lfs_file_opencfg(&lfs, &reader, "open_me",
+            LFS_O_RDONLY, &readercfg) => 0;
+    lfs_file_opencfg(&lfs, &writer, "open_me",
+            LFS_O_WRONLY, &writercfg) => 0;
+    lfs_file_opencfg(&lfs, &snapshot, "open_me",
+            LFS_O_RDONLY | LFS_O_SNAPSHOT, &snapshotcfg) => 0;
+
+    assert(memcmp(readercfg.attrs[0].buffer, "abcd", 4) == 0);
+    for (int j = 0; j < SIZE/2; j++) {
+        lfs_file_read(&lfs, &reader, buffer, 1) => 1;
+        assert(buffer[0] == alphas[j % 26]);
+    }
+
+    assert(memcmp(snapshotcfg.attrs[0].buffer, "abcd", 4) == 0);
+    for (int j = 0; j < SIZE/2; j++) {
+        lfs_file_read(&lfs, &snapshot, buffer, 1) => 1;
+        assert(buffer[0] == alphas[j % 26]);
+    }
+
+    // write file
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_write(&lfs, &writer, &nums[j % 10], 1) => 1;
+    }
+    memcpy(writercfg.attrs[0].buffer, "0123", 4);
+    lfs_file_sync(&lfs, &writer) => 0;
+
+    // reader should change
+    assert(memcmp(readercfg.attrs[0].buffer, "0123", 4) == 0);
+    for (int j = SIZE/2; j < SIZE; j++) {
+        lfs_file_read(&lfs, &reader, buffer, 1) => 1;
+        assert(buffer[0] == nums[j % 10]);
+    }
+
+    // snapshot should remain unchanged
+    assert(memcmp(snapshotcfg.attrs[0].buffer, "abcd", 4) == 0);
+    for (int j = SIZE/2; j < SIZE; j++) {
+        lfs_file_read(&lfs, &snapshot, buffer, 1) => 1;
+        assert(buffer[0] == alphas[j % 26]);
+    }
+
+    lfs_file_close(&lfs, &reader) => 0;
+    lfs_file_close(&lfs, &writer) => 0;
+    lfs_file_close(&lfs, &snapshot) => 0;
+
+    // disk should change
+    lfs_file_opencfg(&lfs, &reader, "open_me",
+            LFS_O_RDONLY, &readercfg) => 0;
+    assert(memcmp(readercfg.attrs[0].buffer, "0123", 4) == 0);
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_read(&lfs, &reader, buffer, 1) => 1;
+        assert(buffer[0] == nums[j % 10]);
+    }
+    lfs_file_close(&lfs, &reader) => 0;
+    lfs_unmount(&lfs) => 0;
+
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_file_opencfg(&lfs, &reader, "open_me",
+            LFS_O_RDONLY, &readercfg) => 0;
+    assert(memcmp(readercfg.attrs[0].buffer, "0123", 4) == 0);
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_read(&lfs, &reader, buffer, 1) => 1;
+        assert(buffer[0] == nums[j % 10]);
+    }
+    lfs_file_close(&lfs, &reader) => 0;
+    lfs_unmount(&lfs) => 0;
+'''
+
+[[case]] # simple snapshot for writing
+define.SIZE = [10, 100, 1000, 10000]
+code = '''
+    const char alphas[] = "abcdefghijklmnopqrstuvwxyz";
+    const char nums[] = "0123456789";
+    lfs_format(&lfs, &cfg) => 0;
+    lfs_mount(&lfs, &cfg) => 0;
+    const struct lfs_file_config filecfg = {
+        .attr_count = 1,
+        .attrs = (struct lfs_attr[]){
+            {'A', "abcd", 4},
+        },
+    };
+    lfs_file_opencfg(&lfs, &file, "open_me",
+            LFS_O_CREAT | LFS_O_WRONLY, &filecfg) => 0;
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_write(&lfs, &file, &alphas[j % 26], 1) => 1;
+    }
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_unmount(&lfs) => 0;
+
+    // open reader/snapshot
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_file_t reader;
+    const struct lfs_file_config readercfg = {
+        .attr_count = 1,
+        .attrs = (struct lfs_attr[]){
+            {'A', &(uint8_t[4]){0}, 4}
+        },
+    };
+    lfs_file_t snapshot;
+    const struct lfs_file_config snapshotcfg = {
+        .attr_count = 1,
+        .attrs = (struct lfs_attr[]){
+            {'A', &(uint8_t[4]){0}, 4}
+        },
+    };
+    lfs_file_opencfg(&lfs, &reader, "open_me",
+            LFS_O_RDONLY, &readercfg) => 0;
+    lfs_file_opencfg(&lfs, &snapshot, "open_me",
+            LFS_O_RDWR | LFS_O_SNAPSHOT, &snapshotcfg) => 0;
+
+    assert(memcmp(readercfg.attrs[0].buffer, "abcd", 4) == 0);
+    for (int j = 0; j < SIZE/2; j++) {
+        lfs_file_read(&lfs, &reader, buffer, 1) => 1;
+        assert(buffer[0] == alphas[j % 26]);
+    }
+
+    assert(memcmp(snapshotcfg.attrs[0].buffer, "abcd", 4) == 0);
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_read(&lfs, &snapshot, buffer, 1) => 1;
+        assert(buffer[0] == alphas[j % 26]);
+    }
+
+    // modify snapshot
+    lfs_file_rewind(&lfs, &snapshot) => 0;
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_write(&lfs, &snapshot, &nums[j % 10], 1) => 1;
+    }
+    memcpy(snapshotcfg.attrs[0].buffer, "0123", 4);
+
+    lfs_file_rewind(&lfs, &snapshot) => 0;
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_read(&lfs, &snapshot, buffer, 1) => 1;
+        assert(buffer[0] == nums[j % 10]);
+    }
+
+    lfs_file_sync(&lfs, &snapshot) => 0;
+
+    // reader should not change
+    assert(memcmp(readercfg.attrs[0].buffer, "abcd", 4) == 0);
+    for (int j = SIZE/2; j < SIZE; j++) {
+        lfs_file_read(&lfs, &reader, buffer, 1) => 1;
+        assert(buffer[0] == alphas[j % 26]);
+    }
+
+    // snapshot should changed
+    assert(memcmp(snapshotcfg.attrs[0].buffer, "0123", 4) == 0);
+    lfs_file_rewind(&lfs, &snapshot) => 0;
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_read(&lfs, &snapshot, buffer, 1) => 1;
+        assert(buffer[0] == nums[j % 10]);
+    }
+
+    lfs_file_close(&lfs, &reader) => 0;
+    lfs_file_close(&lfs, &snapshot) => 0;
+
+    // disk should not change
+    lfs_file_opencfg(&lfs, &reader, "open_me",
+            LFS_O_RDONLY, &readercfg) => 0;
+    assert(memcmp(readercfg.attrs[0].buffer, "abcd", 4) == 0);
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_read(&lfs, &reader, buffer, 1) => 1;
+        assert(buffer[0] == alphas[j % 26]);
+    }
+    lfs_file_close(&lfs, &reader) => 0;
+    lfs_unmount(&lfs) => 0;
+
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_file_opencfg(&lfs, &reader, "open_me",
+            LFS_O_RDONLY, &readercfg) => 0;
+    assert(memcmp(readercfg.attrs[0].buffer, "abcd", 4) == 0);
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_read(&lfs, &reader, buffer, 1) => 1;
+        assert(buffer[0] == alphas[j % 26]);
+    }
+    lfs_file_close(&lfs, &reader) => 0;
+    lfs_unmount(&lfs) => 0;
+'''
+
+[[case]] # temporary files
+define.SIZE = [10, 100, 1000, 10000]
+define.TMP_PATH = 'range(4)'
+code = '''
+    const char alphas[] = "abcdefghijklmnopqrstuvwxyz";
+    const char nums[] = "0123456789";
+    const char caps[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    lfs_format(&lfs, &cfg) => 0;
+    lfs_mount(&lfs, &cfg) => 0;
+    const struct lfs_file_config filecfg = {
+        .attr_count = 1,
+        .attrs = (struct lfs_attr[]){
+            {'A', "abcd", 4},
+        },
+    };
+    lfs_file_opencfg(&lfs, &file, "open_me",
+            LFS_O_CREAT | LFS_O_WRONLY, &filecfg) => 0;
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_write(&lfs, &file, &alphas[j % 26], 1) => 1;
+    }
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_file_opencfg(&lfs, &file, "dont_open_me",
+            LFS_O_CREAT | LFS_O_WRONLY, &filecfg) => 0;
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_write(&lfs, &file, &alphas[j % 26], 1) => 1;
+    }
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_unmount(&lfs) => 0;
+
+    // open reader/writer/temp
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_file_t reader;
+    const struct lfs_file_config readercfg = {
+        .attr_count = 1,
+        .attrs = (struct lfs_attr[]){
+            {'A', &(uint8_t[4]){0}, 4}
+        },
+    };
+    lfs_file_t writer;
+    const struct lfs_file_config writercfg = {
+        .attr_count = 1,
+        .attrs = (struct lfs_attr[]){
+            {'A', &(uint8_t[4]){0}, 4}
+        },
+    };
+    lfs_file_t tmp;
+    const struct lfs_file_config tmpcfg = {
+        .attr_count = 1,
+        .attrs = (struct lfs_attr[]){
+            {'A', &(uint8_t[4]){0}, 4}
+        },
+    };
+    lfs_file_opencfg(&lfs, &reader, "open_me",
+            LFS_O_RDONLY, &readercfg) => 0;
+    lfs_file_opencfg(&lfs, &writer, "open_me",
+            LFS_O_WRONLY, &writercfg) => 0;
+    const char *tmp_paths[] = {NULL, "/", "/tmp", "/open_me.tmp"};
+    lfs_file_opencfg(&lfs, &tmp, tmp_paths[TMP_PATH],
+            LFS_O_RDWR | LFS_O_CREAT | LFS_O_SNAPSHOT, &tmpcfg) => 0;
+
+    assert(memcmp(readercfg.attrs[0].buffer, "abcd", 4) == 0);
+    for (int j = 0; j < SIZE/3; j++) {
+        lfs_file_read(&lfs, &reader, buffer, 1) => 1;
+        assert(buffer[0] == alphas[j % 26]);
+    }
+
+    assert(memcmp(tmpcfg.attrs[0].buffer, "\0\0\0\0", 4) == 0);
+    assert(lfs_file_size(&lfs, &tmp) == 0);
+
+    // write to tmp
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_write(&lfs, &tmp, &nums[j % 10], 1) => 1;
+    }
+    memcpy(tmpcfg.attrs[0].buffer, "0123", 4);
+
+    lfs_file_rewind(&lfs, &tmp) => 0;
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_read(&lfs, &tmp, buffer, 1) => 1;
+        assert(buffer[0] == nums[j % 10]);
+    }
+
+    lfs_file_sync(&lfs, &tmp) => 0;
+
+    // reader should not change
+    assert(memcmp(readercfg.attrs[0].buffer, "abcd", 4) == 0);
+    for (int j = SIZE/3; j < 2*SIZE/3; j++) {
+        lfs_file_read(&lfs, &reader, buffer, 1) => 1;
+        assert(buffer[0] == alphas[j % 26]);
+    }
+
+    // tmp should change
+    assert(memcmp(tmpcfg.attrs[0].buffer, "0123", 4) == 0);
+    lfs_file_rewind(&lfs, &tmp) => 0;
+    for (int j = 0; j < SIZE/2; j++) {
+        lfs_file_read(&lfs, &tmp, buffer, 1) => 1;
+        assert(buffer[0] == nums[j % 10]);
+    }
+
+    // write to file
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_write(&lfs, &writer, &caps[j % 26], 1) => 1;
+    }
+    memcpy(writercfg.attrs[0].buffer, "ABCD", 4);
+    lfs_file_sync(&lfs, &writer) => 0;
+
+    // reader should change
+    assert(memcmp(readercfg.attrs[0].buffer, "ABCD", 4) == 0);
+    for (int j = 2*SIZE/3; j < SIZE; j++) {
+        lfs_file_read(&lfs, &reader, buffer, 1) => 1;
+        assert(buffer[0] == caps[j % 26]);
+    }
+
+    // tmp should not change
+    assert(memcmp(tmpcfg.attrs[0].buffer, "0123", 4) == 0);
+    for (int j = SIZE/2; j < SIZE; j++) {
+        lfs_file_read(&lfs, &tmp, buffer, 1) => 1;
+        assert(buffer[0] == nums[j % 10]);
+    }
+
+    lfs_file_close(&lfs, &reader) => 0;
+    lfs_file_close(&lfs, &writer) => 0;
+    lfs_file_close(&lfs, &tmp) => 0;
+
+    // tmp should not appear on disk
+    lfs_dir_open(&lfs, &dir, "/") => 0;
+    lfs_dir_read(&lfs, &dir, &info) => 1;
+    assert(info.type == LFS_TYPE_DIR);
+    assert(strcmp(info.name, ".") == 0);
+    lfs_dir_read(&lfs, &dir, &info) => 1;
+    assert(info.type == LFS_TYPE_DIR);
+    assert(strcmp(info.name, "..") == 0);
+    lfs_dir_read(&lfs, &dir, &info) => 1;
+    assert(info.type == LFS_TYPE_REG);
+    assert(strcmp(info.name, "dont_open_me") == 0);
+    lfs_dir_read(&lfs, &dir, &info) => 1;
+    assert(info.type == LFS_TYPE_REG);
+    assert(strcmp(info.name, "open_me") == 0);
+    lfs_dir_read(&lfs, &dir, &info) => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_file_opencfg(&lfs, &reader, "open_me",
+            LFS_O_RDONLY, &readercfg) => 0;
+    assert(memcmp(readercfg.attrs[0].buffer, "ABCD", 4) == 0);
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_read(&lfs, &reader, buffer, 1) => 1;
+        assert(buffer[0] == caps[j % 26]);
+    }
+    lfs_file_close(&lfs, &reader) => 0;
+    lfs_file_opencfg(&lfs, &reader, "dont_open_me",
+            LFS_O_RDONLY, &readercfg) => 0;
+    assert(memcmp(readercfg.attrs[0].buffer, "abcd", 4) == 0);
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_read(&lfs, &reader, buffer, 1) => 1;
+        assert(buffer[0] == alphas[j % 26]);
+    }
+    lfs_file_close(&lfs, &reader) => 0;
+    lfs_unmount(&lfs) => 0;
+
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_dir_open(&lfs, &dir, "/") => 0;
+    lfs_dir_read(&lfs, &dir, &info) => 1;
+    assert(info.type == LFS_TYPE_DIR);
+    assert(strcmp(info.name, ".") == 0);
+    lfs_dir_read(&lfs, &dir, &info) => 1;
+    assert(info.type == LFS_TYPE_DIR);
+    assert(strcmp(info.name, "..") == 0);
+    lfs_dir_read(&lfs, &dir, &info) => 1;
+    assert(info.type == LFS_TYPE_REG);
+    assert(strcmp(info.name, "dont_open_me") == 0);
+    lfs_dir_read(&lfs, &dir, &info) => 1;
+    assert(info.type == LFS_TYPE_REG);
+    assert(strcmp(info.name, "open_me") == 0);
+    lfs_dir_read(&lfs, &dir, &info) => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_file_opencfg(&lfs, &reader, "open_me",
+            LFS_O_RDONLY, &readercfg) => 0;
+    assert(memcmp(readercfg.attrs[0].buffer, "ABCD", 4) == 0);
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_read(&lfs, &reader, buffer, 1) => 1;
+        assert(buffer[0] == caps[j % 26]);
+    }
+    lfs_file_close(&lfs, &reader) => 0;
+    lfs_file_opencfg(&lfs, &reader, "dont_open_me",
+            LFS_O_RDONLY, &readercfg) => 0;
+    assert(memcmp(readercfg.attrs[0].buffer, "abcd", 4) == 0);
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_read(&lfs, &reader, buffer, 1) => 1;
+        assert(buffer[0] == alphas[j % 26]);
+    }
+    lfs_file_close(&lfs, &reader) => 0;
+    lfs_unmount(&lfs) => 0;
+'''
+
+[[case]] # test snapshot open errors
+code = '''
+    lfs_format(&lfs, &cfg) => 0;
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_file_open(&lfs, &file, NULL,
+            LFS_O_RDWR | LFS_O_SNAPSHOT) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "/",
+            LFS_O_RDWR | LFS_O_SNAPSHOT) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "/tmp",
+            LFS_O_RDWR | LFS_O_SNAPSHOT) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "/tmp/",
+            LFS_O_RDWR | LFS_O_CREAT | LFS_O_SNAPSHOT) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "/tmp/tmp",
+            LFS_O_RDWR | LFS_O_CREAT | LFS_O_SNAPSHOT) => LFS_ERR_NOENT;
+    lfs_unmount(&lfs) => 0;
+'''

--- a/tests/test_interspersed.toml
+++ b/tests/test_interspersed.toml
@@ -1,7 +1,7 @@
 
 [[case]] # interspersed file test
 define.SIZE = [10, 100]
-define.FILES = [4, 10, 26] 
+define.FILES = [4, 10, 26]
 code = '''
     lfs_file_t files[FILES];
     const char alphas[] = "abcdefghijklmnopqrstuvwxyz";
@@ -55,7 +55,7 @@ code = '''
     for (int j = 0; j < FILES; j++) {
         lfs_file_close(&lfs, &files[j]);
     }
-    
+
     lfs_unmount(&lfs) => 0;
 '''
 
@@ -108,7 +108,7 @@ code = '''
         assert(buffer[0] == '~');
     }
     lfs_file_close(&lfs, &file);
-    
+
     lfs_unmount(&lfs) => 0;
 '''
 
@@ -168,13 +168,13 @@ code = '''
     }
     lfs_file_close(&lfs, &files[0]);
     lfs_file_close(&lfs, &files[1]);
-    
+
     lfs_unmount(&lfs) => 0;
 '''
 
 [[case]] # reentrant interspersed file test
 define.SIZE = [10, 100]
-define.FILES = [4, 10, 26] 
+define.FILES = [4, 10, 26]
 reentrant = true
 code = '''
     lfs_file_t files[FILES];
@@ -239,6 +239,268 @@ code = '''
     for (int j = 0; j < FILES; j++) {
         lfs_file_close(&lfs, &files[j]);
     }
-    
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+[[case]] # open same file reading from separate file handles
+define.READERS = 3
+define.SIZE = [10, 100, 1000, 10000]
+define.RDMODE = ['LFS_O_RDONLY', 'LFS_O_RDWR']
+code = '''
+    const char alphas[] = "abcdefghijklmnopqrstuvwxyz";
+    lfs_format(&lfs, &cfg) => 0;
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_file_open(&lfs, &file, "shared", LFS_O_CREAT | LFS_O_WRONLY) => 0;
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_write(&lfs, &file, &alphas[j % 26], 1) => 1;
+    }
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_unmount(&lfs) => 0;
+
+    // open all files
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_file_t readers[READERS];
+    for (int i = 0; i < READERS; i++) {
+        lfs_file_open(&lfs, &readers[i], "shared", RDMODE) => 0;
+    }
+
+    // perform operations while all readers are open
+    for (int i = 0; i < READERS; i++) {
+        for (int j = 0; j < SIZE; j++) {
+            lfs_file_read(&lfs, &readers[i], buffer, 1) => 1;
+            assert(buffer[0] == alphas[j % 26]);
+        }
+    }
+
+    for (int i = 0; i < READERS; i++) {
+        lfs_file_close(&lfs, &readers[i]) => 0;
+    }
+    lfs_unmount(&lfs) => 0;
+'''
+
+[[case]] # open same file reading and writing from separate file handles
+define.READERS = 3
+define.SIZE = [10, 100, 1000, 10000]
+define.RDMODE = ['LFS_O_RDONLY', 'LFS_O_RDWR']
+define.WRMODE = ['LFS_O_WRONLY', 'LFS_O_RDWR']
+code = '''
+    const char alphas[] = "abcdefghijklmnopqrstuvwxyz";
+    const char nums[] = "0123456789";
+    lfs_format(&lfs, &cfg) => 0;
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_file_open(&lfs, &file, "shared", LFS_O_CREAT | LFS_O_WRONLY) => 0;
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_write(&lfs, &file, &alphas[j % 26], 1) => 1;
+    }
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_unmount(&lfs) => 0;
+
+    // open all files
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_file_t writer;
+    lfs_file_t readers[READERS];
+    lfs_file_open(&lfs, &writer, "shared", WRMODE) => 0;
+    for (int i = 0; i < READERS; i++) {
+        lfs_file_open(&lfs, &readers[i], "shared", RDMODE) => 0;
+    }
+
+    // perform operations while all readers are open
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_write(&lfs, &writer, &nums[j % 10], 1) => 1;
+    }
+
+    for (int i = 0; i < READERS; i++) {
+        for (int j = 0; j < SIZE/2; j++) {
+            lfs_file_read(&lfs, &readers[i], buffer, 1) => 1;
+            assert(buffer[0] == alphas[j % 26]);
+        }
+    }
+
+    // sync, now write should reflect in all open files
+    lfs_file_sync(&lfs, &writer) => 0;
+
+    for (int i = 0; i < READERS; i++) {
+        for (int j = SIZE/2; j < SIZE; j++) {
+            lfs_file_read(&lfs, &readers[i], buffer, 1) => 1;
+            assert(buffer[0] == nums[j % 10]);
+        }
+    }
+
+    // double check our writer reflects its own changes
+    if (WRMODE == LFS_O_RDWR) {
+        lfs_file_rewind(&lfs, &writer) => 0;
+        for (int j = 0; j < SIZE; j++) {
+            lfs_file_read(&lfs, &writer, buffer, 1) => 1;
+            assert(buffer[0] == nums[j % 10]);
+        }
+    }
+
+    for (int i = 0; i < READERS; i++) {
+        lfs_file_close(&lfs, &readers[i]) => 0;
+    }
+    lfs_unmount(&lfs) => 0;
+'''
+
+[[case]] # check that attributes are updated in open files
+define.READERS = 3
+define.SIZE = 10
+define.RDMODE = ['LFS_O_RDONLY', 'LFS_O_RDWR']
+define.WRMODE = ['LFS_O_WRONLY', 'LFS_O_RDWR']
+code = '''
+    const char alphas[] = "abcdefghijklmnopqrstuvwxyz";
+    const char nums[] = "0123456789";
+    lfs_format(&lfs, &cfg) => 0;
+    lfs_mount(&lfs, &cfg) => 0;
+    const struct lfs_file_config filecfg = {
+        .attr_count = 3,
+        .attrs = (struct lfs_attr[]){
+            {'A', "a",   1},
+            {'B', "bb",  2},
+            {'C', "ccc", 3},
+        },
+    };
+    lfs_file_opencfg(&lfs, &file, "shared",
+            LFS_O_CREAT | LFS_O_WRONLY, &filecfg) => 0;
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_write(&lfs, &file, &alphas[j % 26], 1) => 1;
+    }
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_unmount(&lfs) => 0;
+
+    // open all files
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_file_t writer;
+    const struct lfs_file_config writercfg = {
+        .attr_count = 3,
+        .attrs = (struct lfs_attr[]){
+            {'A', &(uint8_t[1]){0}, 1},
+            {'B', &(uint8_t[2]){0}, 2},
+            {'C', &(uint8_t[3]){0}, 3}}};
+    lfs_file_t readers[READERS];
+    const struct lfs_file_config readercfgs[READERS] = {
+        {   .attr_count = 3,
+            .attrs = (struct lfs_attr[]){
+                {'A', &(uint8_t[1]){0}, 1},
+                {'B', &(uint8_t[2]){0}, 2},
+                {'C', &(uint8_t[3]){0}, 3}}},
+        {   .attr_count = 3,
+            .attrs = (struct lfs_attr[]){
+                {'A', &(uint8_t[1]){0}, 1},
+                {'B', &(uint8_t[2]){0}, 2},
+                {'C', &(uint8_t[3]){0}, 3}}},
+        {   .attr_count = 3,
+            .attrs = (struct lfs_attr[]){
+                {'A', &(uint8_t[1]){0}, 1},
+                {'B', &(uint8_t[2]){0}, 2},
+                {'C', &(uint8_t[3]){0}, 3}}}};
+    lfs_file_opencfg(&lfs, &writer, "shared",
+            WRMODE, &writercfg) => 0;
+    for (int i = 0; i < READERS; i++) {
+        lfs_file_opencfg(&lfs, &readers[i], "shared",
+                RDMODE, &readercfgs[i]) => 0;
+    }
+
+    // perform operations while all readers are open
+    writercfg.attrs[0].size = 1;
+    memcpy(writercfg.attrs[0].buffer, "0", 1);
+    writercfg.attrs[1].size = 2;
+    memcpy(writercfg.attrs[1].buffer, "11", 2);
+    writercfg.attrs[2].size = 3;
+    memcpy(writercfg.attrs[2].buffer, "222", 3);
+    for (int j = 0; j < SIZE; j++) {
+        lfs_file_write(&lfs, &writer, &nums[j % 10], 1) => 1;
+    }
+
+    for (int i = 0; i < READERS; i++) {
+        assert(readercfgs[i].attrs[0].size == 1);
+        assert(memcmp(readercfgs[i].attrs[0].buffer, "a", 1) == 0);
+        assert(readercfgs[i].attrs[1].size == 2);
+        assert(memcmp(readercfgs[i].attrs[1].buffer, "bb", 2) == 0);
+        assert(readercfgs[i].attrs[2].size == 3);
+        assert(memcmp(readercfgs[i].attrs[2].buffer, "ccc", 3) == 0);
+        for (int j = 0; j < SIZE; j++) {
+            lfs_file_read(&lfs, &readers[i], buffer, 1) => 1;
+            assert(buffer[0] == alphas[j % 26]);
+        }
+    }
+
+    // sync, now write should reflect in all open files
+    lfs_file_sync(&lfs, &writer) => 0;
+
+    for (int i = 0; i < READERS; i++) {
+        assert(readercfgs[i].attrs[0].size == 1);
+        assert(memcmp(readercfgs[i].attrs[0].buffer, "0", 1) == 0);
+        assert(readercfgs[i].attrs[1].size == 2);
+        assert(memcmp(readercfgs[i].attrs[1].buffer, "11", 2) == 0);
+        assert(readercfgs[i].attrs[2].size == 3);
+        assert(memcmp(readercfgs[i].attrs[2].buffer, "222", 3) == 0);
+        lfs_file_rewind(&lfs, &readers[i]) => 0;
+        for (int j = 0; j < SIZE; j++) {
+            lfs_file_read(&lfs, &readers[i], buffer, 1) => 1;
+            assert(buffer[0] == nums[j % 10]);
+        }
+    }
+
+    // double check our writer reflects its own changes
+    if (WRMODE == LFS_O_RDWR) {
+        assert(writercfg.attrs[0].size == 1);
+        assert(memcmp(writercfg.attrs[0].buffer, "0", 1) == 0);
+        assert(writercfg.attrs[1].size == 2);
+        assert(memcmp(writercfg.attrs[1].buffer, "11", 2) == 0);
+        assert(writercfg.attrs[2].size == 3);
+        assert(memcmp(writercfg.attrs[2].buffer, "222", 3) == 0);
+        lfs_file_rewind(&lfs, &writer) => 0;
+        for (int j = 0; j < SIZE; j++) {
+            lfs_file_read(&lfs, &writer, buffer, 1) => 1;
+            assert(buffer[0] == nums[j % 10]);
+        }
+    }
+
+    // now try explicit lfs_setattr calls, this should still update open files
+    lfs_setattr(&lfs, "shared", 'A', "A",   1) => 0;
+    lfs_setattr(&lfs, "shared", 'B', "BB",  2) => 0;
+    lfs_setattr(&lfs, "shared", 'C', "CCC", 3) => 0;
+
+    for (int i = 0; i < READERS; i++) {
+        assert(readercfgs[i].attrs[0].size == 1);
+        assert(memcmp(readercfgs[i].attrs[0].buffer, "A", 1) == 0);
+        assert(readercfgs[i].attrs[1].size == 2);
+        assert(memcmp(readercfgs[i].attrs[1].buffer, "BB", 2) == 0);
+        assert(readercfgs[i].attrs[2].size == 3);
+        assert(memcmp(readercfgs[i].attrs[2].buffer, "CCC", 3) == 0);
+        lfs_file_rewind(&lfs, &readers[i]) => 0;
+        for (int j = 0; j < SIZE; j++) {
+            lfs_file_read(&lfs, &readers[i], buffer, 1) => 1;
+            assert(buffer[0] == nums[j % 10]);
+        }
+    }
+
+    if (WRMODE == LFS_O_RDWR) {
+        assert(writercfg.attrs[0].size == 1);
+        assert(memcmp(writercfg.attrs[0].buffer, "A", 1) == 0);
+        assert(writercfg.attrs[1].size == 2);
+        assert(memcmp(writercfg.attrs[1].buffer, "BB", 2) == 0);
+        assert(writercfg.attrs[2].size == 3);
+        assert(memcmp(writercfg.attrs[2].buffer, "CCC", 3) == 0);
+        lfs_file_rewind(&lfs, &writer) => 0;
+        for (int j = 0; j < SIZE; j++) {
+            lfs_file_read(&lfs, &writer, buffer, 1) => 1;
+            assert(buffer[0] == nums[j % 10]);
+        }
+    } else if (WRMODE == LFS_O_WRONLY) {
+        // this should NOT update wronly attributes, these may be
+        // stored in read-only memory
+        assert(writercfg.attrs[0].size == 1);
+        assert(memcmp(writercfg.attrs[0].buffer, "0", 1) == 0);
+        assert(writercfg.attrs[1].size == 2);
+        assert(memcmp(writercfg.attrs[1].buffer, "11", 2) == 0);
+        assert(writercfg.attrs[2].size == 3);
+        assert(memcmp(writercfg.attrs[2].buffer, "222", 3) == 0);
+    }
+
+    for (int i = 0; i < READERS; i++) {
+        lfs_file_close(&lfs, &readers[i]) => 0;
+    }
     lfs_unmount(&lfs) => 0;
 '''

--- a/tests/test_paths.toml
+++ b/tests/test_paths.toml
@@ -95,9 +95,9 @@ code = '''
 
     lfs_mkdir(&lfs, "coffee/../milk") => 0;
     lfs_stat(&lfs, "coffee/../milk", &info) => 0;
-    strcmp(info.name, "milk") => 0;
+    assert(strcmp(info.name, "milk") == 0);
     lfs_stat(&lfs, "milk", &info) => 0;
-    strcmp(info.name, "milk") => 0;
+    assert(strcmp(info.name, "milk") == 0);
     lfs_unmount(&lfs) => 0;
 '''
 
@@ -129,9 +129,9 @@ code = '''
     lfs_mount(&lfs, &cfg) => 0;
     lfs_mkdir(&lfs, ".milk") => 0;
     lfs_stat(&lfs, ".milk", &info) => 0;
-    strcmp(info.name, ".milk") => 0;
+    assert(strcmp(info.name, ".milk") == 0);
     lfs_stat(&lfs, "tea/.././.milk", &info) => 0;
-    strcmp(info.name, ".milk") => 0;
+    assert(strcmp(info.name, ".milk") == 0);
     lfs_unmount(&lfs) => 0;
 '''
 
@@ -149,13 +149,13 @@ code = '''
     lfs_mkdir(&lfs, "coffee/coldcoffee") => 0;
 
     lfs_stat(&lfs, "coffee/../../../../../../tea/hottea", &info) => 0;
-    strcmp(info.name, "hottea") => 0;
+    assert(strcmp(info.name, "hottea") == 0);
 
     lfs_mkdir(&lfs, "coffee/../../../../../../milk") => 0;
     lfs_stat(&lfs, "coffee/../../../../../../milk", &info) => 0;
-    strcmp(info.name, "milk") => 0;
+    assert(strcmp(info.name, "milk") == 0);
     lfs_stat(&lfs, "milk", &info) => 0;
-    strcmp(info.name, "milk") => 0;
+    assert(strcmp(info.name, "milk") == 0);
     lfs_unmount(&lfs) => 0;
 '''
 


### PR DESCRIPTION
If https://github.com/littlefs-project/littlefs/pull/491 is merged, it means breaking changes to the API, and a major version bump of some form (but not disk-breaking). This means it's a good time to look at open issues we couldn't fix early without breaking the API.

---

## Cross-file syncing

These changes originally intended to address the issues raised around the behavior of multiple open file handles referencing the same underlying file. Specifically what happens to the other open file handles when you write to one of them?

This issue is explained in more detail by @BrianPugh in https://github.com/littlefs-project/littlefs/issues/483 and https://github.com/joltwallet/esp_littlefs/issues/18

To address this, and make littlefs behave more like other filesystems:
1. On `lfs_file_sync` or `lfs_file_close`, littlefs now updates all file handles (`lfs_file_t`s) open for reading.

   This means readable file handles should always reflect the state of the file on disk.
   
   Some caveats:
   - littlefs copies the state of the writing file handle's cache to the other files, but littlefs's caches are fairly simple. So, unless the open files all have the same file position, any readable file handles will probably need to refetch the state of the file from disk.
   - No changes are reflected until `lfs_file_sync` or `lfs_file_close`. Just like the disk, the state of the file at open is preserved unless another file handle commits new data through either `lfs_file_sync` or `lfs_file_close`.
   - LFS_O_WRONLY file handles are not updated, but LFS_O_RDWR files are. This is to match effects to custom attributes which must not be updated since they may be stored as `const` in read-only memory.

## Custom attribute tweaks

While working on cross-file syncing, I ran into some related issues (https://github.com/littlefs-project/littlefs/issues/183#issuecomment-515627155) on syncing custom attributes. This highlighted some subtle inconsistencies with custom attributes, so I ended up modifying their behavior in a couple ways:
1. In either an explicit `lfs_setattr`, or `lfs_file_sync`/`lfs_file_close` with custom attributes, littlefs now updates the custom attributes attached to any file handles open for reading.
  Just like the file's data, the file's custom attributes should now reflect the state on disk.

2. Reduced when custom attributes are written to strictly when a file is dirty.

   This means if you open a file for writing with attached custom attributes, and then close the file without modification, the custom attributes will not be written out. Previously littlefs would always write out custom attributes on the first `lfs_file_sync`, but this was potentially misleading (if you expect `lfs_file_sync` to always write custom attributes) and ran the risk of creating unnecessary commits.

   Note that files open with `LFS_O_CREAT | LFS_O_TRUNC` are still guaranteed to write out attached custom attributes.
   
   This is explained more in b19a51c.

3. Trailing space in custom attribute buffers are no longer zeroed.

   This previously was a courtesy to help handle custom attributes that may have a different size on disk since `lfs_file_opencfg` has no way to indicate the on-disk file size. However this was a bit difficult to maintain with open file syncing, and was a bit inconsistent.

   If you need to handle differently sized custom attributes, you can either pre-zero the custom attribute buffers, or use `lfs_getattr` to find the on-disk size of custom attributes explicitly.

## LFS_O_SNAPSHOT

Instead of completely removing littlefs's idiosyncratic behavior, I'm considering moving the more useful bits into the LFS_O_SNAPSHOT flag for `lfs_file_open`.

What is LFS_O_SNAPSHOT?

LFS_O_SNAPSHOT allows you to open a "snapshot" of a file. This is a cheap, local copy of a file who's changes are not reflected on disk.

Internally, snapshot files use the same mechanism as pending writes. A separate, copy-on-write CTZ skip-list is created, with read-only references to the existing data blocks until a write occurs. The difference is that snapshot files are not enrolled in the mlist, meaning they won't get updates from open file syncs, and during close their contents are simply discarded.

As an extra benefit, `LFS_O_CREAT | LFS_O_SNAPSHOT` is equivalent to Linux's [O_TMPFILE](https://www.man7.org/linux/man-pages/man2/open.2.html), making it easy to create temporary, unnamed files.

This may be extra useful for embedded development, where unnamed flash-backed buffers may provide a slower, but larger, alternative to RAM-backed buffers.

---

I'm still on the fence on if LFS_O_SNAPSHOT is a worthwhile addition, so I'd be happy to receive any feedback. A quick build showed a ~50 byte code cost for the feature, but I will update with a better measurement if I can.

Initial issues with open-syncing raised by @BrianPugh
Related to https://github.com/littlefs-project/littlefs/issues/483, https://github.com/littlefs-project/littlefs/issues/183