### PR TITLE
lfs_fs_preporphans: return int to alllow graceful LFS_ASSERT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -224,6 +224,22 @@ jobs:
     # report-size will compile littlefs and report the size
     script: [*report-size]
 
+  # test compilation with asserts that return -1
+  - stage: test
+    env:
+      - NAME=littlefs-assert-return
+      - CC="arm-linux-gnueabi-gcc --static -mthumb"
+      - CFLAGS="-Werror -D'LFS_ASSERT(test)=do {if(!(test)) {return -1;}} while(0)'"
+    if: branch !~ -prefix$
+    install:
+      - *install-common
+      - sudo apt-get install
+            gcc-arm-linux-gnueabi
+            libc6-dev-armel-cross
+      - arm-linux-gnueabi-gcc --version
+    # report-size will compile littlefs and report the size
+    script: [*report-size]
+
   # test compilation in thread-safe mode
   - stage: test
     env:

--- a/lfs.h
+++ b/lfs.h
@@ -207,7 +207,7 @@ struct lfs_config {
     // Number of erasable blocks on the device.
     lfs_size_t block_count;
 
-    // Number of erase cycles before littlefs evicts metadata logs and moves 
+    // Number of erase cycles before littlefs evicts metadata logs and moves
     // the metadata to another block. Suggested values are in the
     // range 100-1000, with large values having better performance at the cost
     // of less consistent wear distribution.


### PR DESCRIPTION
From the discussion in #503, I started to implement the split `LFS_ASSERT`/`LFS_ASSERT_RETURN` functionality, but realised that all but one assert already exists in a function returning `int` or `lfs_ssize_t`.

Thus, by changing this function to return `int`, I can continue to use my custom LFS_ASSERT impl:
`#define LFS_ASSERT(test) do {if(!(test)) {log_error("lfs ASSERT %s:%d ", __FILE__, __LINE__); return LFS_ERR_ASSERT;}} while(0)`

Though there aren't any checks in place to prevent newly written LFS_ASSERT-using functions from returning `void`, I added `LFS_ERR_ASSERT` to the `lfs_error` enum to hopefully encourage consistency. Happy to revert that part of the commit.