### PR TITLE
Fix compiler warnings when LFS_READONLY defined

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -11,12 +11,15 @@
 #define LFS_BLOCK_INLINE ((lfs_block_t)-2)
 
 /// Caching block device operations ///
+
+#ifndef LFS_READONLY
 static inline void lfs_cache_drop(lfs_t *lfs, lfs_cache_t *rcache) {
     // do not zero, cheaper if cache is readonly or only going to be
     // written with identical data (during relocates)
     (void)lfs;
     rcache->block = LFS_BLOCK_NULL;
 }
+#endif
 
 static inline void lfs_cache_zero(lfs_t *lfs, lfs_cache_t *pcache) {
     // zero to avoid information leak
@@ -268,22 +271,26 @@ static inline int lfs_pair_cmp(
              paira[0] == pairb[1] || paira[1] == pairb[0]);
 }
 
+#ifndef LFS_READONLY
 static inline bool lfs_pair_sync(
         const lfs_block_t paira[2],
         const lfs_block_t pairb[2]) {
     return (paira[0] == pairb[0] && paira[1] == pairb[1]) ||
            (paira[0] == pairb[1] && paira[1] == pairb[0]);
 }
+#endif
 
 static inline void lfs_pair_fromle32(lfs_block_t pair[2]) {
     pair[0] = lfs_fromle32(pair[0]);
     pair[1] = lfs_fromle32(pair[1]);
 }
 
+#ifndef LFS_READONLY
 static inline void lfs_pair_tole32(lfs_block_t pair[2]) {
     pair[0] = lfs_tole32(pair[0]);
     pair[1] = lfs_tole32(pair[1]);
 }
+#endif
 
 // operations on 32-bit entry tags
 typedef uint32_t lfs_tag_t;
@@ -365,6 +372,7 @@ static inline bool lfs_gstate_iszero(const lfs_gstate_t *a) {
     return true;
 }
 
+#ifndef LFS_READONLY
 static inline bool lfs_gstate_hasorphans(const lfs_gstate_t *a) {
     return lfs_tag_size(a->tag);
 }
@@ -376,6 +384,7 @@ static inline uint8_t lfs_gstate_getorphans(const lfs_gstate_t *a) {
 static inline bool lfs_gstate_hasmove(const lfs_gstate_t *a) {
     return lfs_tag_type1(a->tag);
 }
+#endif
 
 static inline bool lfs_gstate_hasmovehere(const lfs_gstate_t *a,
         const lfs_block_t *pair) {
@@ -388,11 +397,13 @@ static inline void lfs_gstate_fromle32(lfs_gstate_t *a) {
     a->pair[1] = lfs_fromle32(a->pair[1]);
 }
 
+#ifndef LFS_READONLY
 static inline void lfs_gstate_tole32(lfs_gstate_t *a) {
     a->tag     = lfs_tole32(a->tag);
     a->pair[0] = lfs_tole32(a->pair[0]);
     a->pair[1] = lfs_tole32(a->pair[1]);
 }
+#endif
 
 // other endianness operations
 static void lfs_ctz_fromle32(struct lfs_ctz *ctz) {
@@ -416,6 +427,7 @@ static inline void lfs_superblock_fromle32(lfs_superblock_t *superblock) {
     superblock->attr_max    = lfs_fromle32(superblock->attr_max);
 }
 
+#ifndef LFS_READONLY
 static inline void lfs_superblock_tole32(lfs_superblock_t *superblock) {
     superblock->version     = lfs_tole32(superblock->version);
     superblock->block_size  = lfs_tole32(superblock->block_size);
@@ -424,6 +436,7 @@ static inline void lfs_superblock_tole32(lfs_superblock_t *superblock) {
     superblock->file_max    = lfs_tole32(superblock->file_max);
     superblock->attr_max    = lfs_tole32(superblock->attr_max);
 }
+#endif
 
 #ifndef LFS_NO_ASSERT
 static bool lfs_mlist_isopen(struct lfs_mlist *head,


### PR DESCRIPTION
Without this patch, when defining `LFS_READONLY`:

```
littlefs/lfs.c:14:20: warning: unused function 'lfs_cache_drop' [-Wunused-function]
static inline void lfs_cache_drop(lfs_t *lfs, lfs_cache_t *rcache) {
                   ^
littlefs/lfs.c:271:20: warning: unused function 'lfs_pair_sync' [-Wunused-function]
static inline bool lfs_pair_sync(
                   ^
littlefs/lfs.c:283:20: warning: unused function 'lfs_pair_tole32' [-Wunused-function]
static inline void lfs_pair_tole32(lfs_block_t pair[2]) {
                   ^
littlefs/lfs.c:368:20: warning: unused function 'lfs_gstate_hasorphans' [-Wunused-function]
static inline bool lfs_gstate_hasorphans(const lfs_gstate_t *a) {
                   ^
littlefs/lfs.c:372:23: warning: unused function 'lfs_gstate_getorphans' [-Wunused-function]
static inline uint8_t lfs_gstate_getorphans(const lfs_gstate_t *a) {
                      ^
littlefs/lfs.c:376:20: warning: unused function 'lfs_gstate_hasmove' [-Wunused-function]
static inline bool lfs_gstate_hasmove(const lfs_gstate_t *a) {
                   ^
littlefs/lfs.c:391:20: warning: unused function 'lfs_gstate_tole32' [-Wunused-function]
static inline void lfs_gstate_tole32(lfs_gstate_t *a) {
                   ^
littlefs/lfs.c:419:20: warning: unused function 'lfs_superblock_tole32' [-Wunused-function]
static inline void lfs_superblock_tole32(lfs_superblock_t *superblock) {
                   ^
8 warnings generated.
```