### PR TITLE
Add littlefs-disk-img-viewer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ License Identifiers that are here available: http://spdx.org/licenses/
   your needs, create images for a later download to the target memory or
   inspect the content of a binary image of the target memory.
 
+- [littlefs-disk-img-viewer] - A memory-efficient web application for viewing
+  littlefs disk images in your web browser.
+
 - [mklfs] - A command line tool built by the [Lua RTOS] guys for making
   littlefs images from a host PC. Supports Windows, Mac OS, and Linux.
 
@@ -245,6 +248,7 @@ License Identifiers that are here available: http://spdx.org/licenses/
 
 
 [BSD-3-Clause]: https://spdx.org/licenses/BSD-3-Clause.html
+[littlefs-disk-img-viewer]: https://tniessen.github.io/littlefs-disk-img-viewer/
 [littlefs-fuse]: https://github.com/geky/littlefs-fuse
 [FUSE]: https://github.com/libfuse/libfuse
 [littlefs-js]: https://github.com/geky/littlefs-js

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ License Identifiers that are here available: http://spdx.org/licenses/
 
 
 [BSD-3-Clause]: https://spdx.org/licenses/BSD-3-Clause.html
-[littlefs-disk-img-viewer]: https://tniessen.github.io/littlefs-disk-img-viewer/
+[littlefs-disk-img-viewer]: https://github.com/tniessen/littlefs-disk-img-viewer
 [littlefs-fuse]: https://github.com/geky/littlefs-fuse
 [FUSE]: https://github.com/libfuse/libfuse
 [littlefs-js]: https://github.com/geky/littlefs-js


### PR DESCRIPTION
This is a tool that I've been working on. It should be capable of opening littlefs disk images up to a size of 4 GiB and allows browsing the folder structure, "downloading" files from the file system, etc.

The tool doesn't support all of the features of littlefs yet (e.g., viewing folder attributes), but it's [getting there](https://github.com/tniessen/littlefs-disk-img-viewer).