### PR TITLE
Add attribute operation, use file parameter

### DIFF
--- a/lfs.h
+++ b/lfs.h
@@ -550,6 +550,7 @@ int lfs_file_close(lfs_t *lfs, lfs_file_t *file);
 // Returns a negative error code on failure.
 int lfs_file_sync(lfs_t *lfs, lfs_file_t *file);
 
+
 // Read data from file
 //
 // Takes a buffer and size indicating where to store the read data.
@@ -599,6 +600,42 @@ int lfs_file_rewind(lfs_t *lfs, lfs_file_t *file);
 // Similar to lfs_file_seek(lfs, file, 0, LFS_SEEK_END)
 // Returns the size of the file, or a negative error code on failure.
 lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file);
+
+// Get a custom attribute of file
+//
+// Custom attributes are uniquely identified by an 8-bit type and limited
+// to LFS_ATTR_MAX bytes. When read, if the stored attribute is smaller than
+// the buffer, it will be padded with zeros. If the stored attribute is larger,
+// then it will be silently truncated. If no attribute is found, the error
+// LFS_ERR_NOATTR is returned and the buffer is filled with zeros.
+//
+// Returns the size of the attribute, or a negative error code on failure.
+// Note, the returned size is the size of the attribute on disk, irrespective
+// of the size of the buffer. This can be used to dynamically allocate a buffer
+// or check for existance.
+lfs_ssize_t lfs_file_getattr(lfs_t *lfs, lfs_file_t *file,
+        uint8_t type, void *buffer, lfs_size_t size);
+
+// Set custom attributes of file
+//
+// Custom attributes are uniquely identified by an 8-bit type and limited
+// to LFS_ATTR_MAX bytes. If an attribute is not found, it will be
+// implicitly created.
+//
+// Returns a negative error code on failure.
+#ifndef LFS_READONLY
+int lfs_file_setattr(lfs_t *lfs, lfs_file_t *file,
+        uint8_t type, const void *buffer, lfs_size_t size);
+#endif
+
+// Removes a custom attribute of file
+//
+// If an attribute is not found, nothing happens.
+//
+// Returns a negative error code on failure.
+#ifndef LFS_READONLY
+int lfs_file_removeattr(lfs_t *lfs, lfs_file_t *file, uint8_t type);
+#endif
 
 
 /// Directory operations ///


### PR DESCRIPTION
I found that in the process of using littlefs, sometimes the save path is not obtained or obtained, and the custom attribute cannot be used at this time. I think it is better to add a file parameter, it allows us to apply more scenarios, and can also save memory usage in some cases, and this function is also helpful for nuttx's vfs