### PR TITLE
Fail mount when the block size changes

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -3762,10 +3762,17 @@ static int lfs_rawmount(lfs_t *lfs, const struct lfs_config *cfg) {
                 lfs->attr_max = superblock.attr_max;
             }
 
-            if ((superblock.block_count != lfs->cfg->block_count) ||
-                (superblock.block_size != lfs->cfg->block_size))
-            {
-                err = LFS_ERR_CORRUPT;
+            if (superblock.block_count != lfs->cfg->block_count) {
+                LFS_ERROR("Invalid block count (%"PRIu32" != %"PRIu32")",
+                        superblock.block_count, lfs->cfg->block_count);
+                err = LFS_ERR_INVAL;
+                goto cleanup;
+            }
+
+            if (superblock.block_size != lfs->cfg->block_size) {
+                LFS_ERROR("Invalid block size (%"PRIu32" != %"PRIu32")",
+                        superblock.block_count, lfs->cfg->block_count);
+                err = LFS_ERR_INVAL;
                 goto cleanup;
             }
         }

--- a/lfs.c
+++ b/lfs.c
@@ -3761,6 +3761,12 @@ static int lfs_rawmount(lfs_t *lfs, const struct lfs_config *cfg) {
 
                 lfs->attr_max = superblock.attr_max;
             }
+
+            if (superblock.block_count != lfs->cfg->block_count)
+            {
+                err = LFS_ERR_CORRUPT;
+                goto cleanup;
+            }
         }
 
         // has gstate?

--- a/lfs.c
+++ b/lfs.c
@@ -3762,7 +3762,8 @@ static int lfs_rawmount(lfs_t *lfs, const struct lfs_config *cfg) {
                 lfs->attr_max = superblock.attr_max;
             }
 
-            if (superblock.block_count != lfs->cfg->block_count)
+            if ((superblock.block_count != lfs->cfg->block_count) ||
+                (superblock.block_size != lfs->cfg->block_size))
             {
                 err = LFS_ERR_CORRUPT;
                 goto cleanup;


### PR DESCRIPTION
When the on-disk block size doesn't match the config block size, it is
possible to get file corruption. For instance, if the num blocks was
0x200 and we re-mount with 0x100 files could be corrupt.

If we re-mount with a larger number of blocks things should be safer,
but could be handled with a resize option or perhaps a mount flag to
ignore this parameter.