### PR TITLE
New API function lfs_find_free_blocks. 

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -662,7 +662,9 @@ static int lfs_alloc(lfs_t *lfs, lfs_block_t *block) {
 }
 
 int lfs_find_free_blocks(lfs_t *lfs){
-    lfs->free.off = (lfs->free.off + lfs->free.size)
+    // Move free offset at the first unused block (lfs->free.i)
+    // lfs->free.i is equal lfs->free.size when all blocks are used
+    lfs->free.off = (lfs->free.off + lfs->free.i)
         % lfs->cfg->block_count;
     lfs->free.size = lfs_min(8*lfs->cfg->lookahead_size, lfs->free.ack);
     lfs->free.i = 0;

--- a/lfs.h
+++ b/lfs.h
@@ -705,6 +705,10 @@ lfs_ssize_t lfs_fs_size(lfs_t *lfs);
 // Returns a negative error code on failure.
 int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 
+// Use Traverse function and try to find free blocks. LittleFS free blocks search is unpredictable.
+// Search is costly operation which may delay write. In realtime write scenarios can be better to find them before a write.
+int lfs_find_free_blocks(lfs_t *lfs);
+
 #ifndef LFS_READONLY
 // Attempt to make the filesystem consistent and ready for writing
 //


### PR DESCRIPTION
It performs a free block search which later will not slow down a write operation.

It helps to have predictable write times. In scenarios like storing data from a microphone. Write taken too long when littlefs does the free block search during it.

I am open to other solutions.
