### PR TITLE
Always zero rambd buffer before first use

### DIFF
--- a/bd/lfs_rambd.c
+++ b/bd/lfs_rambd.c
@@ -36,6 +36,8 @@ int lfs_rambd_createcfg(const struct lfs_config *cfg,
     if (bd->cfg->erase_value != -1) {
         memset(bd->buffer, bd->cfg->erase_value,
                 cfg->block_size * cfg->block_count);
+    } else {
+        memset(bd->buffer, 0, cfg->block_size * cfg->block_count);
     }
 
     LFS_RAMBD_TRACE("lfs_rambd_createcfg -> %d", 0);


### PR DESCRIPTION
This fixes warnings produced by tools such as memcheck without requiring the user to set an erase value.

```
==3983== Use of uninitialised value of size 8
==3983==    at 0x114F2E: lfs_crc (lfs_util.c:25)
==3983==    by 0x10C3B4: lfs_dir_commitprog (lfs.c:1287)
==3983==    by 0x10D147: lfs_dir_compact (lfs.c:1695)
==3983==    by 0x10DE71: lfs_dir_commit (lfs.c:1959)
==3983==    by 0x1120C7: lfs_rawformat (lfs.c:3643)
==3983==    by 0x11383A: lfs_format (lfs.c:4938)
==3983==    by 0x1158EA: main (test.c:43)

...

==3983== Conditional jump or move depends on uninitialised value(s)
==3983==    at 0x10B1FE: lfs_dir_traverse (lfs.c:805)
==3983==    by 0x10B1A3: lfs_dir_traverse (lfs.c:786)
==3983==    by 0x10D1EC: lfs_dir_compact (lfs.c:1706)
==3983==    by 0x10DE71: lfs_dir_commit (lfs.c:1959)
==3983==    by 0x1120F7: lfs_rawformat (lfs.c:3655)
==3983==    by 0x11383A: lfs_format (lfs.c:4938)
==3983==    by 0x1158EA: main (test.c:43)
```