### PR TITLE
don't use lfs_file_open() when LFS_NO_MALLOC is set

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -5082,6 +5082,7 @@ int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type) {
 }
 #endif
 
+#ifndef LFS_NO_MALLOC
 int lfs_file_open(lfs_t *lfs, lfs_file_t *file, const char *path, int flags) {
     int err = LFS_LOCK(lfs->cfg);
     if (err) {
@@ -5097,6 +5098,7 @@ int lfs_file_open(lfs_t *lfs, lfs_file_t *file, const char *path, int flags) {
     LFS_UNLOCK(lfs->cfg);
     return err;
 }
+#endif
 
 int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags,

--- a/lfs.h
+++ b/lfs.h
@@ -513,6 +513,7 @@ int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type);
 
 /// File operations ///
 
+#ifndef LFS_NO_MALLOC
 // Open a file
 //
 // The mode that the file is opened in is determined by the flags, which
@@ -521,6 +522,10 @@ int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type);
 // Returns a negative error code on failure.
 int lfs_file_open(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags);
+
+// if LFS_NO_MALLOC is defined, lfs_file_open() will fail with LFS_ERR_NOMEM
+// thus use lfs_file_opencfg() with config.buffer set.
+#endif
 
 // Open a file with extra configuration
 //


### PR DESCRIPTION
fixing my previous fix

just prevent the use of lfs_file_open() when LFS_NO_MALLOC is set.
because it fails with the return code LFS_ERR_NOMEM due to lfs_malloc() returning NULL in lfs_file_rawopencfg (lfs.c:2578).