### PR TITLE
RFC: various optimization targeting 'rename' and "compact' (but not only...)

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -888,6 +888,37 @@ static int lfs_dir_traverse(lfs_t *lfs,
         } else if (lfs_tag_type3(tag) == LFS_FROM_MOVE) {
             uint16_t fromid = lfs_tag_size(tag);
             uint16_t toid = lfs_tag_id(tag);
+            /*
+             * There is a huge room for simple optimization for the rename case
+             * where we can see up to 4 levels of lfs_dir_traverse recursions when
+             * compaction happened:
+             * ex:
+             * >lfs_dir_compact
+             *  [1] lfs_dir_traverse(cb=lfs_dir_commit_size)
+             *      - do 'duplicates and tag update'
+             *    [2] lfs_dir_traverse(cb=lfs_dir_traverse_filter, data=tag[1])
+             *        - Reaching a LFS_FROM_MOVE tag (here)
+             *      [3] lfs_dir_traverse(cb=lfs_dir_traverse_filter, data=tag[1]) <= on 'from' dir
+             *          - do 'duplicates and tag update'
+             *        [4] lfs_dir_traverse(cb=lfs_dir_traverse_filter, data=tag[3])
+             *
+             * Yet, for LFS_FROM_MOVE when cb == lfs_dir_traverse_filter
+             * traverse [3] and [4] don't do anything:
+             * - if [2] is supposed to match 'toid' for dupplication, a preceding
+             *   ERASE or CREATE with the same tag id will already had stop the search.
+             * - if [2] is here to update tag value of CREATE/DELETE attr found during the
+             *   scan, since [3] is looking for LFS_TYPE_STRUCT only and call
+             *   lfs_dir_traverse_filter with LFS_TYPE_STRUCT attr wheras
+             *   lfs_dir_traverse_filter only modify tag on CREATE or DELETE.
+             *   Consequently, cb called from [4] will never stop the search from [2}
+             * - [4] may call lfs_dir_traverse_filter, but with action on a tag[3] pointer
+             *   completely different from tag[1]
+             */
+            if (cb == lfs_dir_traverse_filter) {
+                continue;
+            }
+
+            /* note: buffer = oldcwd dir */
             int err = lfs_dir_traverse(lfs,
                     buffer, 0, 0xffffffff, NULL, 0,
                     LFS_MKTAG(0x600, 0x3ff, 0),

--- a/lfs.h
+++ b/lfs.h
@@ -322,8 +322,19 @@ typedef struct lfs_cache {
     lfs_block_t block;
     lfs_off_t off;
     lfs_size_t size;
+#ifdef LFS_DYN_CACHE
+    uint16_t block_match_count;
+#endif
     uint8_t *buffer;
 } lfs_cache_t;
+
+
+#ifdef LFS_DYN_CACHE
+typedef struct lfs_dyn_cache {
+    lfs_block_t block;
+    uint8_t *buffer;
+} lfs_dyn_cache_t;
+#endif
 
 typedef struct lfs_mdir {
     lfs_block_t pair[2];
@@ -386,6 +397,9 @@ typedef struct lfs_gstate {
 typedef struct lfs {
     lfs_cache_t rcache;
     lfs_cache_t pcache;
+#ifdef LFS_DYN_CACHE
+    lfs_dyn_cache_t dyn_rcache;
+#endif
 
     lfs_block_t root[2];
     struct lfs_mlist {

--- a/lfs_util.c
+++ b/lfs_util.c
@@ -6,6 +6,11 @@
  */
 #include "lfs_util.h"
 
+#ifdef LFS_PERF_STATS
+struct lfs_perf_stats lfs_perf_stats = {0};
+#endif
+
+
 // Only compile if user does not provide custom config
 #ifndef LFS_CONFIG
 

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -235,6 +235,31 @@ static inline void lfs_free(void *p) {
 #endif
 }
 
+#ifdef LFS_PERF_STATS
+struct lfs_perf_stats {
+	unsigned bd_read_calls;
+	unsigned bd_read_bytes;
+
+	unsigned io_read_calls;
+	unsigned io_read_bytes;
+
+	unsigned io_erase_calls;
+	unsigned io_prog_calls;
+	unsigned io_prog_bytes;
+
+	unsigned dir_compact_calls;
+	unsigned dir_traverse_calls;
+};
+
+extern struct lfs_perf_stats lfs_perf_stats;
+#define LFS_PERF_STATS_INCR(counter, count)  lfs_perf_stats.counter += (count)
+#define LFS_PERF_STATS_RESET()  memset(&lfs_perf_stats, 0, sizeof(lfs_perf_stats));
+#define LFS_PERF_STATS_GET(counter) (lfs_perf_stats.counter)
+#else
+#define LFS_PERF_STATS_INCR(counter, count)
+#define LFS_PERF_STATS_RESET()
+#define LFS_PERF_STATS_GET(counter) (0)
+#endif
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
Hello.
While we are working with littlefs for few months, we experience few long stall of the system during up to 30s, despite having a solid hardware (250+ MHz ARM M33, lot of RAM, 50 MB/s of NOR flash bus speed).

Our investigation quickly focused on the rename operations that are used for atomic file substitution. 
The issues are similar to #327.

In order to easily reproduce the issue we found the following scenario which is very representative of the problem:
```
    - format and mount a 4KB block FS
    - create 100 files of 256 Bytes named "/dummy_%d"
    - create a 1024 Byte file "/test"
    - rename "/test" "/test_rename"
    - create a 1024 Byte file "/test"
    - rename "/test" "/test_rename"  [1]
```
The second rename [1] trigger a compaction of the dir. 
We measure various performance counters: 
- `lfs_dir_traverse` is called 148 393 times
- `lfs_bd_read` is called 25 205 444 times (for 100MB+ of data requested)
- With current cache implementation, 13 872 154 SPI read transfers where done (222MB+ of data transfers).
**THIS IS HUGE** for a 102 files / 28KB filled FS....

We provide here 2 cache improvements and a simple but very effective `lfs_dir_traverse` optimization.
All the optimizations are independent.
1) The cache "read ahead" optimization simply request larger rcache fill when it detects that reads are continuous.
  => 66% reduction if IO operations
  => 20% increase of data transfers on SPI
  => 33% overall time reduction of SPI transfers (since the effective data transfers is only a  small part of the SPI command sequence)

2) A "dynamic" block caching (enabled with `LFS_DYN_CACHE` define) to malloc a whole block when we detect random consecutive read on a single block. the RAM allocated is freed as soon as the user `lfs_xxxxx` operation returns. Consequently it should not increase heap usage as long as there is a single block temporary available in RAM.
=> **99.997 %** reduction of IO operations  (compared to (1))  - only 123 remaining block read vs. 13872154
=> **99.993 %** reduction of IO data transfer - only 15KB vs. 222MB.
When RAM (eg. 4KB for our plaform) is not an issue, this is a very interesting optimization.

3) Yet, despite (2), the overall CPU time only decrease by 75%, leaving the huge number of times `lfs_dir_traverse` is called.
We analyze the call graph and saw that 4 levels of recursive calls of `lfs_dir_traverse` are done during compaction.
A O(n^4) is obviously a problem...
The 4 level is due to the presence of LFS_FROM_MOVE tag is attribute walk list.
```
 [1] lfs_dir_traverse(cb=lfs_dir_commit_size)
     - do 'duplicates and tag update'
   [2] lfs_dir_traverse(cb=lfs_dir_traverse_filter, data=tag[1])
       - Reaching a LFS_FROM_MOVE tag (here)
     [3] lfs_dir_traverse(cb=lfs_dir_traverse_filter, data=tag[1]) <= on 'from' dir
         - do 'duplicates and tag update'
       [4] lfs_dir_traverse(cb=lfs_dir_traverse_filter, data=tag[3])
```
Yet, for the particular case of cb=lfs_dir_traverse_filter for [3] and [4], we saw that all the calls are useless 
- can't raise 'duplicate' trigger of [2]