### PR TITLE
Removed invalid overwrite for return value.

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -2513,8 +2513,11 @@ static int lfs_file_rawopencfg(lfs_t *lfs, lfs_file_t *file,
                 {LFS_MKTAG(LFS_TYPE_CREATE, file->id, 0), NULL},
                 {LFS_MKTAG(LFS_TYPE_REG, file->id, nlen), path},
                 {LFS_MKTAG(LFS_TYPE_INLINESTRUCT, file->id, 0), NULL}));
+
+        // it may happen that the file name doesn't fit in the metadata blocks, e.g., a 256 byte file name will
+        // not fit in a 128 byte block.
+        err = (err == LFS_ERR_NOSPC) ? LFS_ERR_NAMETOOLONG : err;
         if (err) {
-            err = LFS_ERR_NAMETOOLONG;
             goto cleanup;
         }
 


### PR DESCRIPTION
While working on a `littlefs` integration I've received the return value `LFS_ERR_NAMETOOLONG` for several error scenarios where it doesn't apply. I think the affected line may have been copied by mistake.

E.g., I've received this return value for an invalid block device driver where I've messed up the offsets within the memory and also with bugs in an optimized CRC32 calculation.