### PR TITLE
Fixes to use lfs_filebd on windows platforms

### DIFF
--- a/bd/lfs_filebd.c
+++ b/bd/lfs_filebd.c
@@ -11,9 +11,7 @@
 #include <errno.h>
 
 #ifdef _WIN32
-// Map fsync to FlushFileBuffers on Windows
 #include <windows.h>
-#define fsync(fd) (FlushFileBuffers ((HANDLE) _get_osfhandle(fd)) ? 0 : -1)
 #endif
 
 int lfs_filebd_createcfg(const struct lfs_config *cfg, const char *path,
@@ -204,7 +202,11 @@ int lfs_filebd_sync(const struct lfs_config *cfg) {
     LFS_FILEBD_TRACE("lfs_filebd_sync(%p)", (void*)cfg);
     // file sync
     lfs_filebd_t *bd = cfg->context;
+    #ifdef _WIN32
+    int err = FlushFileBuffers((HANDLE) _get_osfhandle(fd)) ? 0 : -1;
+    #else
     int err = fsync(bd->fd);
+    #endif
     if (err) {
         err = -errno;
         LFS_FILEBD_TRACE("lfs_filebd_sync -> %d", 0);

--- a/bd/lfs_filebd.c
+++ b/bd/lfs_filebd.c
@@ -14,11 +14,8 @@
 // Map fsync to FlushFileBuffers on Windows
 #include <windows.h>
 #define fsync(fd) (FlushFileBuffers ((HANDLE) _get_osfhandle(fd)) ? 0 : -1)
-#else
-// O_BINARY is required and exists for Windows platforms.
-// For Linux it is not needed thus 0
-#define O_BINARY 0
 #endif
+
 int lfs_filebd_createcfg(const struct lfs_config *cfg, const char *path,
         const struct lfs_filebd_config *bdcfg) {
     LFS_FILEBD_TRACE("lfs_filebd_createcfg(%p {.context=%p, "
@@ -36,7 +33,12 @@ int lfs_filebd_createcfg(const struct lfs_config *cfg, const char *path,
     bd->cfg = bdcfg;
 
     // open file
+    #ifdef _WIN32
     bd->fd = open(path, O_RDWR | O_CREAT | O_BINARY, 0666);
+    #else
+    bd->fd = open(path, O_RDWR | O_CREAT, 0666);
+    #endif
+
     if (bd->fd < 0) {
         int err = -errno;
         LFS_FILEBD_TRACE("lfs_filebd_createcfg -> %d", err);


### PR DESCRIPTION
There are two issues, when using the file-based block device emulation
on Windows Platforms:
1. There is no fsync implementation available. This needs to be mapped
   to a Windows-specific FlushFileBuffers system call.
2. The block device file needs to be opened as binary file (O_BINARY)
	   The corresponding flag is not required for Linux.