### PR TITLE
Allow lfs_crc to be explicitly enabled even with a custom config

### DIFF
--- a/lfs_util.c
+++ b/lfs_util.c
@@ -6,9 +6,14 @@
  */
 #include "lfs_util.h"
 
-// Only compile if user does not provide custom config
+// Only compile if the user does not provide a custom config or if the
+// user has explicitly requested the implementation with the define
+// LFS_SOFTWARE_CRC_WITH_SMALL_LOOKUP
 #ifndef LFS_CONFIG
+#define LFS_SOFTWARE_CRC_WITH_SMALL_LOOKUP
+#endif
 
+#ifdef LFS_SOFTWARE_CRC_WITH_SMALL_LOOKUP
 
 // Software CRC implementation with small lookup table
 uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size) {


### PR DESCRIPTION
Retain the behaviour of ifdef'ing out lfs_crc when a user has supplied
a custom config. But allow the user to explicitly enable the
implementation with the define LFS_SOFTWARE_CRC_WITH_SMALL_LOOKUP

This allows users with custom config's to re-use this lfs_crc
implementation.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>