### PR TITLE
Update copyright notice

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,4 @@
+Copyright (c) 2022, The littlefs authors.  
 Copyright (c) 2017, Arm Limited. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/bd/lfs_filebd.c
+++ b/bd/lfs_filebd.c
@@ -1,6 +1,7 @@
 /*
  * Block device emulated in a file
  *
+ * Copyright (c) 2022, The littlefs authors.
  * Copyright (c) 2017, Arm Limited. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/bd/lfs_filebd.h
+++ b/bd/lfs_filebd.h
@@ -1,6 +1,7 @@
 /*
  * Block device emulated in a file
  *
+ * Copyright (c) 2022, The littlefs authors.
  * Copyright (c) 2017, Arm Limited. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/bd/lfs_rambd.c
+++ b/bd/lfs_rambd.c
@@ -1,6 +1,7 @@
 /*
  * Block device emulated in RAM
  *
+ * Copyright (c) 2022, The littlefs authors.
  * Copyright (c) 2017, Arm Limited. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/bd/lfs_rambd.h
+++ b/bd/lfs_rambd.h
@@ -1,6 +1,7 @@
 /*
  * Block device emulated in RAM
  *
+ * Copyright (c) 2022, The littlefs authors.
  * Copyright (c) 2017, Arm Limited. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/bd/lfs_testbd.c
+++ b/bd/lfs_testbd.c
@@ -2,6 +2,7 @@
  * Testing block device, wraps filebd and rambd while providing a bunch
  * of hooks for testing littlefs in various conditions.
  *
+ * Copyright (c) 2022, The littlefs authors.
  * Copyright (c) 2017, Arm Limited. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/bd/lfs_testbd.h
+++ b/bd/lfs_testbd.h
@@ -2,6 +2,7 @@
  * Testing block device, wraps filebd and rambd while providing a bunch
  * of hooks for testing littlefs in various conditions.
  *
+ * Copyright (c) 2022, The littlefs authors.
  * Copyright (c) 2017, Arm Limited. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/lfs.c
+++ b/lfs.c
@@ -1,6 +1,7 @@
 /*
  * The little filesystem
  *
+ * Copyright (c) 2022, The littlefs authors.
  * Copyright (c) 2017, Arm Limited. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/lfs.h
+++ b/lfs.h
@@ -1,6 +1,7 @@
 /*
  * The little filesystem
  *
+ * Copyright (c) 2022, The littlefs authors.
  * Copyright (c) 2017, Arm Limited. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/lfs_util.c
+++ b/lfs_util.c
@@ -1,6 +1,7 @@
 /*
  * lfs util functions
  *
+ * Copyright (c) 2022, The littlefs authors.
  * Copyright (c) 2017, Arm Limited. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -1,6 +1,7 @@
 /*
  * lfs utility functions
  *
+ * Copyright (c) 2022, The littlefs authors.
  * Copyright (c) 2017, Arm Limited. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */


### PR DESCRIPTION
Update the copyright notice to note the owner as the littlefs project moving forward.

This should have no impact on the current license (littlefs is still available under BSD 3-Clause), but just documents an ownership change.

littlefs was at one point funded by Arm under [Mbed OS](https://github.com/ARMmbed/mbed-os), but it hasn't been this way for a while. With the permission from the head of OSO at Arm, this has been moved into the category of personal project, with myself taking ownership. This is a mutual change as it clarifies that the direction of littlefs has zero reflection on Arm.

For full transparency, I'm still employed at Arm, but my work has little to do with littlefs at the moment. Anything I write here is my own. Employment aside, I'm personally still very interested in developing/maintaining littlefs and seeing where it goes.