### PR TITLE
Fix unused function warning with LFS_NO_MALLOC

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -2998,12 +2998,14 @@ cleanup:
     return err;
 }
 
+#ifndef LFS_NO_MALLOC
 static int lfs_file_rawopen(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags) {
     static const struct lfs_file_config defaults = {0};
     int err = lfs_file_rawopencfg(lfs, file, path, flags, &defaults);
     return err;
 }
+#endif
 
 static int lfs_file_rawclose(lfs_t *lfs, lfs_file_t *file) {
 #ifndef LFS_READONLY


### PR DESCRIPTION
If you compile lfs.c with LFS_NO_MALLOC defined you get an unused function warning for `lfs_file_rawopen`.

If you're compiling with `-Werror` that becomes an error:
```
third_party/littlefs/lfs.c:3001:12: error: 'lfs_file_rawopen' defined but not used [-Werror=unused-function]
 3001 | static int lfs_file_rawopen(lfs_t *lfs, lfs_file_t *file,
      |            ^~~~~~~~~~~~~~~~
```

This pull request fixes the warning.