### PR TITLE
Fix lfs_gstate_hasmove always return 0 if bool is defined as uint8_t.

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -390,7 +390,7 @@ static inline uint8_t lfs_gstate_getorphans(const lfs_gstate_t *a) {
 }
 
 static inline bool lfs_gstate_hasmove(const lfs_gstate_t *a) {
-    return lfs_tag_type1(a->tag);
+    return lfs_tag_type1(a->tag) != 0;
 }
 #endif
 


### PR DESCRIPTION
static inline bool lfs_gstate_hasmove(const lfs_gstate_t *a) {
    return lfs_tag_type1(a->tag);
}
if bool is defined as uint8_t, this function always return 0. This is caused by  truncate return value of uint16_t to uint8.

I have also notice other functions may have the same bug, they are:
lfs_gstate_getorphans
lfs_gstate_hasorphans
I am not sure about them though.

Signed-off-by: 田昕 <tianxin7@xiaomi.com>