### PR TITLE
[issue 551] Optimized lfs_bd_cmp() and lfs_file_relocate() for bad block reloction.

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -14,7 +14,7 @@
 #define LFS_BLOCK_INLINE ((lfs_block_t)-2)
 
 #define LFS_BULK_RELOC_SIZE 32
-#define LFS_BULK_CMP_SIZE 0
+#define LFS_BULK_CMP_SIZE 8
 
 enum {
     LFS_OK_RELOCATED = 1,


### PR DESCRIPTION
to specify a bulk compare / transfer size in bytes.