### PR TITLE
Reserve large fixed-size flat address spaces as files

### DIFF
--- a/lfs.h
+++ b/lfs.h
@@ -604,7 +604,7 @@ int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
 // committed due to any error, flag LFS_F_ERRED before closing.
 //
 // Returns a negative error code on failure.
-int lfs_file_reserve(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
+int lfs_file_reserve(lfs_t *lfs, lfs_file_t *file, lfs_size_t size);
 
 // Return the position of the file
 //

--- a/lfs.h
+++ b/lfs.h
@@ -30,7 +30,7 @@ extern "C"
 // Version of On-disk data structures
 // Major (top-nibble), incremented on backwards incompatible changes
 // Minor (bottom-nibble), incremented on feature additions
-#define LFS_DISK_VERSION 0x00020000
+#define LFS_DISK_VERSION 0x00020001
 #define LFS_DISK_VERSION_MAJOR (0xffff & (LFS_DISK_VERSION >> 16))
 #define LFS_DISK_VERSION_MINOR (0xffff & (LFS_DISK_VERSION >>  0))
 
@@ -109,6 +109,7 @@ enum lfs_type {
     LFS_TYPE_DELETE         = 0x4ff,
     LFS_TYPE_SUPERBLOCK     = 0x0ff,
     LFS_TYPE_DIRSTRUCT      = 0x200,
+    LFS_TYPE_FLATSTRUCT     = 0x203,
     LFS_TYPE_CTZSTRUCT      = 0x202,
     LFS_TYPE_INLINESTRUCT   = 0x201,
     LFS_TYPE_SOFTTAIL       = 0x600,
@@ -144,6 +145,7 @@ enum lfs_open_flags {
     LFS_F_ERRED   = 0x080000, // An error occurred during write
 #endif
     LFS_F_INLINE  = 0x100000, // Currently inlined in directory entry
+    LFS_F_FLAT    = 0x200000, // A flat fixed length file
 };
 
 // File seek flags
@@ -587,6 +589,22 @@ lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
 // Returns a negative error code on failure.
 int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
 #endif
+
+// Reserve a flat storage area of the specified size
+//
+// Reserves a flat fixed-size area in the storage of the specified size.
+// The area is not usable as a real file. The reserved blocks can be
+// used directly.
+// 
+// Any previous contents of the file will be discarded entirely.
+// To turn the file back into a regular file, set its size to 0.
+// 
+// After writing to a newly reserved area, close must be called to
+// commit the reservation to the storage. If the file should not be
+// committed due to any error, flag LFS_F_ERRED before closing.
+//
+// Returns a negative error code on failure.
+int lfs_file_reserve(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
 
 // Return the position of the file
 //


### PR DESCRIPTION
The EVE graphics controller can render ASTC textures straight from SPI flash. We plan to integrate LittleFS to enable easy asset replacement. One requirement is that the ASTC texture is located in one contiguous area. The current file allocation strategy does not permit this due to the block header in files larger than one block.

To achieve our requirements, this PR adds an additional file record type `LFS_TYPE_FLATSTRUCT` flagged by `LFS_F_FLAT`. This record simply stores the first block number and the file size. During block traversal, all the blocks starting from the first block until the last are simply visited (without accessing storage). This allows us to effectively reserve flat address spaces in flash within the filesystem.

A function `lfs_file_reserve` is added to turn a file into a reserved flat address space. Calling this function will discard the file and attempt to allocate the requested size as a contiguous block. Specifying size 0 will discard the reservation and make the file usable as a regular file again. As we are accessing the reserved storage areas directly from the GPU, no implementation of read nor write is provided.

To allocate the contiguous blocks, two strategies are used depending on the size of the file.

The first allocation strategy is to simply allocate blocks, and reset the allocation starting point whenever an expected block is skipped over, until the expected number of blocks has been allocated sequentially. The strategy is used when the file size is smaller than the allocation cache, and is aborted when more blocks than are contained in the cache have been attempted.

The second allocation strategy allocates one block regularly. Then traverses the filesystem and advances the allocation starting point anytime a block is found that collides with the expected allocation space, past the colliding block. The traversal is repeated until a traversal is done with no collisions, and aborted if the attempted starting point has looped around the address space.

When calling the reserve function on an existing already reserved file, a new allocation is made. As the updated file record is only committed to the storage upon closing the file, and when no error is flagged, this mechanism is suitable for safely upgrading large assets on flash.

# Usage

## Writing a large file

```c
lfs_file_open(&lfs, &file, filename, LFS_O_WR | LFS_O_CREAT);
lfs_file_reserve(&lfs, &file, size);

// Erase, write, and verify from GPU RAM directly to SPI flash
EVE_CoCmd_flashUpdate(phost, EVE_FLASH_BLOB_SIZE + (file->block * lfs->cfg->block_size), gpuSrcAddr, size);
if (!EVE_Cmd_waitFlush(phost)) file->flags |= LFS_F_ERRED; // Flag any error

lfs_file_close(&lfs, &file);
```

## Reading a large file

```c
lfs_file_open(&lfs, &file, filename, LFS_O_RD);

// Read from SPI flash directly to GPU RAM
EVE_CoCmd_flashRead(phost, gpuSrcAddr, EVE_FLASH_BLOB_SIZE + (file->block * lfs->cfg->block_size), size); 
// (Or, alternatively, use the flash address to render ASTC textures directly from SPI flash)

lfs_file_close(&lfs, &file);
```