### PR TITLE
Fix buffer overflow in tests when using a large block size

### DIFF
--- a/scripts/test.py
+++ b/scripts/test.py
@@ -93,7 +93,7 @@ PROLOGUE = """
     __attribute__((unused)) lfs_dir_t dir;
     __attribute__((unused)) struct lfs_info info;
     __attribute__((unused)) char path[1024];
-    __attribute__((unused)) uint8_t buffer[1024];
+    __attribute__((unused)) uint8_t buffer[(1024 > LFS_BLOCK_SIZE * 4) ? (1024) : (LFS_BLOCK_SIZE * 4)];
     __attribute__((unused)) lfs_size_t size;
     __attribute__((unused)) int err;
     


### PR DESCRIPTION
One of the *test_evil.toml* case reads 4x the block size into `buffer`, which is hardcoded to 1024 bytes. This causes a buffer overrun when testing with large block sizes.

```c
__attribute__((unused)) uint8_t buffer[1024];
// ...
define.SIZE = ['2*LFS_BLOCK_SIZE', '3*LFS_BLOCK_SIZE', '4*LFS_BLOCK_SIZE']
// ...
lfs_file_read(&lfs, &file, buffer, SIZE) => LFS_ERR_CORRUPT;
```

This patch sizes the buffer to the largest of 1024 and 4x the block size.