### PR TITLE
Add "chamelon" to the related projects section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ License Identifiers that are here available: http://spdx.org/licenses/
   MCUs. It offers static wear-leveling and power-resilience with only a fixed
   _O(|address|)_ pointer structure stored on each block and in RAM.
 
+- [chamelon] - A pure-OCaml implementation of (most of) littlefs, designed for
+  use with the MirageOS library operating system project. It is interoperable
+  with the reference implementation, with some caveats.
 
 [BSD-3-Clause]: https://spdx.org/licenses/BSD-3-Clause.html
 [littlefs-fuse]: https://github.com/geky/littlefs-fuse
@@ -256,3 +259,4 @@ License Identifiers that are here available: http://spdx.org/licenses/
 [SPIFFS]: https://github.com/pellepl/spiffs
 [Dhara]: https://github.com/dlbeer/dhara
 [littlefs-python]: https://pypi.org/project/littlefs-python/
+[chamelon]: https://github.com/yomimono/chamelon


### PR DESCRIPTION
"chamelon" implements a subset of littlefs (no global move state or
singly-linked list threaded through the directory tree) for use in the
MirageOS library operating system project. It is written entirely in
OCaml and is interoperable (with the above caveats) with the reference
implementation via FUSE.