### PR TITLE
Fix self-assign warnings discovered by clang, remove some warning flags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -292,6 +292,27 @@ jobs:
       - name: test-valgrind
         run: make test TESTFLAGS+="-k --valgrind"
 
+  # test that compilation is warning free under clang
+  clang:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: install
+        run: |
+          # need toml, also pip3 isn't installed by default?
+          sudo apt-get update -qq
+          sudo apt-get install -qq python3 python3-pip
+          sudo pip3 install toml
+      - name: install-clang
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qq clang
+          echo "CC=clang" >> $GITHUB_ENV
+          clang --version
+      # no reason to not test again
+      - name: test-clang
+        run: make test TESTFLAGS+="-k"
+
   # self-host with littlefs-fuse for a fuzz-like test
   fuse:
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,7 @@ override CFLAGS += -DLFS_YES_TRACE
 endif
 override CFLAGS += -g3
 override CFLAGS += -I.
-override CFLAGS += -std=c99 -Wall -pedantic
-override CFLAGS += -Wextra -Wshadow -Wjump-misses-init -Wundef
+override CFLAGS += -std=c99 -Wall -Wextra -pedantic
 
 ifdef VERBOSE
 override TESTFLAGS     += -v

--- a/lfs.c
+++ b/lfs.c
@@ -865,11 +865,6 @@ static int lfs_dir_traverse(lfs_t *lfs,
                 };
                 sp += 1;
 
-                dir = dir;
-                off = off;
-                ptag = ptag;
-                attrs = attrs;
-                attrcount = attrcount;
                 tmask = 0;
                 ttag = 0;
                 begin = 0;


### PR DESCRIPTION
This was a false positive, but having clean warnings in clang would be good to have. See https://github.com/littlefs-project/littlefs/issues/684 for more info.

Also added clang compilation to CI.

---

Note that I've also removed some of the extra warning flags applied to littlefs up until this point. Some are not available in clang, and I've been meaning to remove these for a while as I've not found them more annoying than useful.

Found by @dpgeorge 