### PR TITLE
Fix lfs_dir_fetchmatch not propogating bd errors correctly in one case

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -1162,6 +1162,7 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
                         dir->erased = false;
                         break;
                     }
+                    return err;
                 }
                 lfs_pair_fromle32(temptail);
             }


### PR DESCRIPTION
See https://github.com/littlefs-project/littlefs/issues/739 for more info. Should resolve https://github.com/littlefs-project/littlefs/issues/739.

cc @cbiffle
