### PR TITLE
Don't rely on implicit bool-cast in lfs_gstate_hasmove()

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -390,7 +390,7 @@ static inline uint8_t lfs_gstate_getorphans(const lfs_gstate_t *a) {
 }
 
 static inline bool lfs_gstate_hasmove(const lfs_gstate_t *a) {
-    return lfs_tag_type1(a->tag);
+    return !!lfs_tag_type1(a->tag);
 }
 #endif
 


### PR DESCRIPTION
bool could be defined to be an (unsigned) char, which causes the expression in lfs_gstate_hasmove() to always evaluate to false since the truth:y value is kept in the upper 8 bits of the uint16_t which will get truncated in the implicit cast.

This will further bring with it that the compiler may then determine that lfs_gstate_hasmove() can never return true, and while optimizing removing the lfs_dir_commit() of oldcwd in lfs_rawrename(). Leading to a corrupt file system where files and directories are duplicated.

Signed-off-by: John Ernberg <john.ernberg@actia.se>