### PR TITLE
Do not call lfs_free if the buffer to free is NULL

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -3014,7 +3014,7 @@ static int lfs_file_rawclose(lfs_t *lfs, lfs_file_t *file) {
     lfs_mlist_remove(lfs, (struct lfs_mlist*)file);
 
     // clean up memory
-    if (!file->cfg->buffer) {
+    if ((!file->cfg->buffer) && (file->cache.buffer)) {
         lfs_free(file->cache.buffer);
     }
 


### PR DESCRIPTION
This can happen if lfs_malloc fails, or if the file doesn't exist, all "goto cleanup" clauses before and including the the lfs_malloc will cause this.