### PR TITLE
Add missing iterations in tests

### DIFF
--- a/tests/test_dirs.toml
+++ b/tests/test_dirs.toml
@@ -727,7 +727,7 @@ code = '''
     }
     lfs_unmount(&lfs) => 0;
 
-    for (int j = 2; j < COUNT; j++) {
+    for (int j = 2; j < COUNT + 2; j++) {
         lfs_mount(&lfs, &cfg) => 0;
         lfs_dir_open(&lfs, &dir, "hello") => 0;
         lfs_dir_read(&lfs, &dir, &info) => 1;
@@ -787,7 +787,7 @@ code = '''
     }
     lfs_unmount(&lfs) => 0;
 
-    for (int j = 2; j < COUNT; j++) {
+    for (int j = 2; j < COUNT + 2; j++) {
         lfs_mount(&lfs, &cfg) => 0;
         lfs_dir_open(&lfs, &dir, "/") => 0;
         lfs_dir_read(&lfs, &dir, &info) => 1;


### PR DESCRIPTION
The tests don't actually test every file.
The iteration skips the two `.` and `..` directories, which means that the last two files were not read. This PR fixes that. This seems to reach an edge case reported in #785.

As can be seen, the tests fail at a call to `lfs_dir_seek`, when they shouldn't.