### PR TITLE
Add littlefs2 crate to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ License Identifiers that are here available: http://spdx.org/licenses/
   to create images of the filesystem on your PC. Check if littlefs will fit
   your needs, create images for a later download to the target memory or
   inspect the content of a binary image of the target memory.
+  
+- [littlefs2-rust] - Idiomatic Rust API for the littlefs microcontroller
+  filesystem with ow-level bindings provided by the [littlefs2-sys] crate.
+  
 
 - [mklfs] - A command line tool built by the [Lua RTOS] guys for making
   littlefs images from a host PC. Supports Windows, Mac OS, and Linux.
@@ -256,3 +260,5 @@ License Identifiers that are here available: http://spdx.org/licenses/
 [SPIFFS]: https://github.com/pellepl/spiffs
 [Dhara]: https://github.com/dlbeer/dhara
 [littlefs-python]: https://pypi.org/project/littlefs-python/
+[littlefs2-rust]: https://crates.io/crates/littlefs2
+[littlefs2-sys]: https://crates.io/crates/littlefs2-sys

--- a/README.md
+++ b/README.md
@@ -227,9 +227,9 @@ License Identifiers that are here available: http://spdx.org/licenses/
   your needs, create images for a later download to the target memory or
   inspect the content of a binary image of the target memory.
   
-- [littlefs2-rust] - Idiomatic Rust API for the littlefs microcontroller
-  filesystem with ow-level bindings provided by the [littlefs2-sys] crate.
-  
+- [littlefs2-rust] - A Rust wrapper for littlefs. This project allows you
+  to use littlefs in a Rust-friendly API, reaping the benefits of Rust's memory
+  safety and other guarantees.
 
 - [mklfs] - A command line tool built by the [Lua RTOS] guys for making
   littlefs images from a host PC. Supports Windows, Mac OS, and Linux.
@@ -261,4 +261,3 @@ License Identifiers that are here available: http://spdx.org/licenses/
 [Dhara]: https://github.com/dlbeer/dhara
 [littlefs-python]: https://pypi.org/project/littlefs-python/
 [littlefs2-rust]: https://crates.io/crates/littlefs2
-[littlefs2-sys]: https://crates.io/crates/littlefs2-sys


### PR DESCRIPTION
The latest crate release supports 2.1.4, however, it's still a good idea to add the crate to your list :yum: imo