### PR TITLE
Sets all allocated buffer pointers to NULL after they are free()-ed. …

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -3016,6 +3016,7 @@ static int lfs_file_rawclose(lfs_t *lfs, lfs_file_t *file) {
     // clean up memory
     if (!file->cfg->buffer) {
         lfs_free(file->cache.buffer);
+        file->cache.buffer = NULL;
     }
 
     return err;
@@ -4014,14 +4015,17 @@ static int lfs_deinit(lfs_t *lfs) {
     // free allocated memory
     if (!lfs->cfg->read_buffer) {
         lfs_free(lfs->rcache.buffer);
+        lfs->rcache.buffer = NULL;
     }
 
     if (!lfs->cfg->prog_buffer) {
         lfs_free(lfs->pcache.buffer);
+        lfs->pcache.buffer = NULL;
     }
 
     if (!lfs->cfg->lookahead_buffer) {
         lfs_free(lfs->free.buffer);
+        lfs->free.buffer = NULL;
     }
 
     return 0;


### PR DESCRIPTION
…This prevents calling free() with random memory addresses.
Issue is easily reproduced by: lfs_mount() -> lfs_unmount() -> lfs_unmount()

This has been discussed in #764 and #776
