### PR TITLE
Add an assert for truthy-preserving bool conversions

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -3905,6 +3905,12 @@ static int lfs_init(lfs_t *lfs, const struct lfs_config *cfg) {
     lfs->cfg = cfg;
     int err = 0;
 
+    // check that bool is a truthy-preserving type
+    //
+    // note the most common reason for this failure is a before-c99 compiler,
+    // which littlefs currently does not support
+    LFS_ASSERT((bool)0x80000000);
+
     // validate that the lfs-cfg sizes were initiated properly before
     // performing any arithmetic logics with them
     LFS_ASSERT(lfs->cfg->read_size != 0);


### PR DESCRIPTION
This has caught enough people that an explicit assert is warranted.

How littlefs, a c99 project, should be integrated with c89 projects is still an open question, but no one deserves to debug this sort of undetected casting issue.

Found by @johnernberg and @XinStellaris. This an alternative to https://github.com/littlefs-project/littlefs/pull/772 and https://github.com/littlefs-project/littlefs/pull/677.
