### PR TITLE
Add explicit assert for minimum block size of 128 bytes

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -3917,7 +3917,10 @@ static int lfs_init(lfs_t *lfs, const struct lfs_config *cfg) {
     LFS_ASSERT(lfs->cfg->cache_size % lfs->cfg->prog_size == 0);
     LFS_ASSERT(lfs->cfg->block_size % lfs->cfg->cache_size == 0);
 
-    // check that the block size is large enough to fit ctz pointers
+    // check that the block size is large enough to fit all ctz pointers
+    LFS_ASSERT(lfs->cfg->block_size >= 128);
+    // this is the exact calculation for all ctz pointers, if this fails
+    // and the simpler assert above does not, math must be broken
     LFS_ASSERT(4*lfs_npw2(0xffffffff / (lfs->cfg->block_size-2*4))
             <= lfs->cfg->block_size);
 


### PR DESCRIPTION
See https://github.com/littlefs-project/littlefs/issues/264 for more info.

There was already an assert for this, but because it included the underlying equation for the requirement it was too confusing for users that had no prior knowledge for why the assert could trigger.

The math works out such that 128 bytes is a reasonable minimum requirement, so I've added that number as an explicit assert. Hopefully this makes this sort of situation easier to debug.

Note that this requirement would need to be increased to 512 bytes if block addresses are ever increased to 64-bits. [DESIGN.md#ctz-skip-lists](https://github.com/littlefs-project/littlefs/blob/master/DESIGN.md#ctz-skip-lists) goes into more detail why this is.