### PR TITLE
Convince GitHub littlefs is a C project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# GitHub really wants to mark littlefs as a python project, telling it to
+# reclassify our test .toml files as C code (which they are 95% of anyways)
+# remedies this
+*.toml linguist-language=c


### PR DESCRIPTION
This reclassifies .toml files in littlefs as .c files for the purpose of GitHub's search/language detection.

With the new test framework, GitHub really wants to mark littlefs as a python project:

![image](https://user-images.githubusercontent.com/1075160/236329702-2f09e10c-2048-4fd4-a3e0-36f147cc2c70.png)

Telling GitHub to reclassify our test .toml files as C code (which they are 95% of anyways) remedies this.

An alternative would be to add syntax=c vim modelines to the test/bench files, which would also render them with C syntax highlighting on GitHub. Unfortunately the interspersed toml metadata mucks this up, making the result not very useful.

GitHub's language detection/workarounds are document over here:
https://github.com/github-linguist/linguist

This is low-priority, so will wait to merge it until there is another reason for a patch release.