### PR TITLE
Fix build for AVR

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -1651,7 +1651,7 @@ static int lfs_dir_commitcrc(lfs_t *lfs, struct lfs_commit *commit) {
 
         commit->off = noff;
         // perturb valid bit?
-        commit->ptag = ntag ^ ((0x80 & ~eperturb) << 24);
+        commit->ptag = ntag ^ ((0x80UL & ~eperturb) << 24);
         // reset crc for next commit
         commit->crc = 0xffffffff;
 


### PR DESCRIPTION
This fixes the overflowing left shift on 8 bit platforms.

    littlefs2/lfs.c: In function ‘lfs_dir_commitcrc’:
    littlefs2/lfs.c:1654:51: error: left shift count >= width of type [-Werror=shift-count-overflow]
             commit->ptag = ntag ^ ((0x80 & ~eperturb) << 24);