### PR TITLE
Fix compilation with Clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,21 @@ else
 TARGET ?= $(BUILDDIR)/liblfs.a
 endif
 
+HOST_OS ?= $(shell uname -s)
 
+ifeq ($(HOST_OS),Darwin)
+CC       ?= clang
+else
 CC       ?= gcc
+endif
 AR       ?= ar
 SIZE     ?= size
 CTAGS    ?= ctags
 NM       ?= nm
 OBJDUMP  ?= objdump
 VALGRIND ?= valgrind
-GDB		 ?= gdb
-PERF	 ?= perf
+GDB      ?= gdb
+PERF     ?= perf
 
 SRC  ?= $(filter-out $(wildcard *.t.* *.b.*),$(wildcard *.c))
 OBJ  := $(SRC:%.c=$(BUILDDIR)/%.o)
@@ -59,11 +64,13 @@ BENCH_PERF  := $(BENCH_RUNNER:%=%.perf)
 BENCH_TRACE := $(BENCH_RUNNER:%=%.trace)
 BENCH_CSV   := $(BENCH_RUNNER:%=%.csv)
 
-CFLAGS += -fcallgraph-info=su
 CFLAGS += -g3
 CFLAGS += -I.
 CFLAGS += -std=c99 -Wall -Wextra -pedantic
+ifeq ($(CC),gcc)
+CFLAGS += -fcallgraph-info=su
 CFLAGS += -ftrack-macro-expansion=0
+endif
 ifdef DEBUG
 CFLAGS += -O0
 else
@@ -417,7 +424,7 @@ endif
 # note we remove some binary dependent files during compilation,
 # otherwise it's way to easy to end up with outdated results
 bench-runner build-bench: $(BENCH_RUNNER)
-ifdef YES_COV 
+ifdef YES_COV
 	rm -f $(BENCH_GCDA)
 endif
 ifdef YES_PERF

--- a/lfs.c
+++ b/lfs.c
@@ -4311,7 +4311,8 @@ static int lfs_rawmount(lfs_t *lfs, const struct lfs_config *cfg) {
                 LFS_ERROR("Invalid version "
                         "v%"PRIu16".%"PRIu16" != v%"PRIu16".%"PRIu16,
                         major_version, minor_version,
-                        LFS_DISK_VERSION_MAJOR, LFS_DISK_VERSION_MINOR);
+                        (uint16_t)LFS_DISK_VERSION_MAJOR,
+                        (uint16_t)LFS_DISK_VERSION_MINOR);
                 err = LFS_ERR_INVAL;
                 goto cleanup;
             }
@@ -4323,7 +4324,8 @@ static int lfs_rawmount(lfs_t *lfs, const struct lfs_config *cfg) {
                 LFS_DEBUG("Found older minor version "
                         "v%"PRIu16".%"PRIu16" < v%"PRIu16".%"PRIu16,
                         major_version, minor_version,
-                        LFS_DISK_VERSION_MAJOR, LFS_DISK_VERSION_MINOR);
+                        (uint16_t)LFS_DISK_VERSION_MAJOR,
+                        (uint16_t)LFS_DISK_VERSION_MINOR);
             #ifndef LFS_READONLY
                 // note this bit is reserved on disk, so fetching more gstate
                 // will not interfere here


### PR DESCRIPTION
Avoid passing GCC-specific flags to non-GCC $CC
Build with Clang on Darwin targets.
Fix a print format warning when an int is passed to format PRIu16