### PR TITLE
Remove unnecessary sys/types.h include

### DIFF
--- a/lfs_util.h
+++ b/lfs_util.h
@@ -23,7 +23,6 @@
 // System includes
 #include <stdint.h>
 #include <stdbool.h>
-#include <sys/types.h>
 #include <string.h>
 #include <inttypes.h>
 


### PR DESCRIPTION
Likely included at some point for `ssize_t`, this is no longer needed and causes some problems for embedded compilers.

Currently littlefs doesn't even use `size_t`/`ssize_t` in its definition of `lfs_size_t`/`lfs_ssize_t`, so I don't think this will ever be required.

Found by @LDong-Arm, @vvn-git