### PR TITLE
Add lfs_fs_stat for access to filesystem status/configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -371,7 +371,8 @@ jobs:
       # on one geometry
       - name: test-valgrind
         run: |
-          TESTFLAGS="$TESTFLAGS --valgrind -Gdefault -Pnone" make test
+          TESTFLAGS="$TESTFLAGS --valgrind --context=1024 -Gdefault -Pnone" \
+            make test
 
   # test that compilation is warning free under clang
   # run with Clang, mostly to check for Clang-specific warnings

--- a/lfs.c
+++ b/lfs.c
@@ -4424,7 +4424,7 @@ static int lfs_fs_rawstat(lfs_t *lfs, struct lfs_fsinfo *fsinfo) {
     // if the superblock is up-to-date, we must be on the most recent
     // minor version of littlefs
     if (!lfs_gstate_needssuperblock(&lfs->gstate)) {
-        fsinfo->minor_version = LFS_DISK_VERSION_MINOR;
+        fsinfo->disk_version = LFS_DISK_VERSION;
 
     // otherwise we need to read the minor version on disk
     } else {
@@ -4444,8 +4444,8 @@ static int lfs_fs_rawstat(lfs_t *lfs, struct lfs_fsinfo *fsinfo) {
         }
         lfs_superblock_fromle32(&superblock);
 
-        // read the minor version
-        fsinfo->minor_version = (0xffff & (superblock.version >> 0));
+        // read the on-disk version
+        fsinfo->disk_version = superblock.version;
     }
 
     // find the current block usage

--- a/lfs.c
+++ b/lfs.c
@@ -415,11 +415,11 @@ static inline uint8_t lfs_gstate_getorphans(const lfs_gstate_t *a) {
 static inline bool lfs_gstate_hasmove(const lfs_gstate_t *a) {
     return lfs_tag_type1(a->tag);
 }
+#endif
 
 static inline bool lfs_gstate_needssuperblock(const lfs_gstate_t *a) {
     return lfs_tag_size(a->tag) >> 9;
 }
-#endif
 
 static inline bool lfs_gstate_hasmovehere(const lfs_gstate_t *a,
         const lfs_block_t *pair) {
@@ -535,7 +535,6 @@ static int lfs_file_outline(lfs_t *lfs, lfs_file_t *file);
 static int lfs_file_flush(lfs_t *lfs, lfs_file_t *file);
 
 static int lfs_fs_deorphan(lfs_t *lfs, bool powerloss);
-static void lfs_fs_prepsuperblock(lfs_t *lfs, bool needssuperblock);
 static int lfs_fs_preporphans(lfs_t *lfs, int8_t orphans);
 static void lfs_fs_prepmove(lfs_t *lfs,
         uint16_t id, const lfs_block_t pair[2]);
@@ -545,6 +544,8 @@ static lfs_stag_t lfs_fs_parent(lfs_t *lfs, const lfs_block_t dir[2],
         lfs_mdir_t *parent);
 static int lfs_fs_forceconsistency(lfs_t *lfs);
 #endif
+
+static void lfs_fs_prepsuperblock(lfs_t *lfs, bool needssuperblock);
 
 #ifdef LFS_MIGRATE
 static int lfs1_traverse(lfs_t *lfs,
@@ -4672,12 +4673,10 @@ static lfs_stag_t lfs_fs_parent(lfs_t *lfs, const lfs_block_t pair[2],
 }
 #endif
 
-#ifndef LFS_READONLY
 static void lfs_fs_prepsuperblock(lfs_t *lfs, bool needssuperblock) {
     lfs->gstate.tag = (lfs->gstate.tag & ~LFS_MKTAG(0, 0, 0x200))
             | (uint32_t)needssuperblock << 9;
 }
-#endif
 
 #ifndef LFS_READONLY
 static int lfs_fs_preporphans(lfs_t *lfs, int8_t orphans) {

--- a/lfs.c
+++ b/lfs.c
@@ -4448,13 +4448,6 @@ static int lfs_fs_rawstat(lfs_t *lfs, struct lfs_fsinfo *fsinfo) {
         fsinfo->disk_version = superblock.version;
     }
 
-    // find the current block usage
-    lfs_ssize_t usage = lfs_fs_rawsize(lfs);
-    if (usage < 0) {
-        return usage;
-    }
-    fsinfo->block_usage = usage;
-
     // other on-disk configuration, we cache all of these for internal use
     fsinfo->name_max = lfs->name_max;
     fsinfo->file_max = lfs->file_max;

--- a/lfs.h
+++ b/lfs.h
@@ -280,6 +280,27 @@ struct lfs_info {
     char name[LFS_NAME_MAX+1];
 };
 
+// Filesystem info structure
+struct lfs_fsinfo {
+    // On-disk minor version.
+    uint16_t minor_version;
+
+    // Number of blocks in use, this is the same as lfs_fs_size.
+    //
+    // Note: block_usage is best effort. If files share COW structures, the
+    // calculated block_usage may be larger than the actual contents on-disk.
+    lfs_size_t block_usage;
+
+    // Upper limit on the length of file names in bytes.
+    lfs_size_t name_max;
+
+    // Upper limit on the size of files in bytes.
+    lfs_size_t file_max;
+
+    // Upper limit on the size of custom attributes in bytes.
+    lfs_size_t attr_max;
+};
+
 // Custom attribute structure, used to describe custom attributes
 // committed atomically during file writes.
 struct lfs_attr {
@@ -658,6 +679,12 @@ int lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir);
 
 
 /// Filesystem-level filesystem operations
+
+// Find on-disk info about the filesystem
+//
+// Fills out the fsinfo structure based on the filesystem found on-disk.
+// Returns a negative error code on failure.
+int lfs_fs_stat(lfs_t *lfs, struct lfs_fsinfo *fsinfo);
 
 // Finds the current size of the filesystem
 //

--- a/lfs.h
+++ b/lfs.h
@@ -285,12 +285,6 @@ struct lfs_fsinfo {
     // On-disk version.
     uint32_t disk_version;
 
-    // Number of blocks in use, this is the same as lfs_fs_size.
-    //
-    // Note: block_usage is best effort. If files share COW structures, the
-    // calculated block_usage may be larger than the actual contents on-disk.
-    lfs_size_t block_usage;
-
     // Upper limit on the length of file names in bytes.
     lfs_size_t name_max;
 

--- a/lfs.h
+++ b/lfs.h
@@ -282,8 +282,8 @@ struct lfs_info {
 
 // Filesystem info structure
 struct lfs_fsinfo {
-    // On-disk minor version.
-    uint16_t minor_version;
+    // On-disk version.
+    uint32_t disk_version;
 
     // Number of blocks in use, this is the same as lfs_fs_size.
     //

--- a/tests/test_compat.toml
+++ b/tests/test_compat.toml
@@ -80,7 +80,7 @@ code = '''
     // we should be able to read the version using lfs_fs_stat
     struct lfs_fsinfo fsinfo;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFSP_DISK_VERSION_MINOR);
+    assert(fsinfo.disk_version == LFSP_DISK_VERSION);
 
     lfs_unmount(&lfs) => 0;
 '''
@@ -113,7 +113,7 @@ code = '''
     // we should be able to read the version using lfs_fs_stat
     struct lfs_fsinfo fsinfo;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFSP_DISK_VERSION_MINOR);
+    assert(fsinfo.disk_version == LFSP_DISK_VERSION);
 
     // can we list the directories?
     lfs_dir_t dir;
@@ -182,7 +182,7 @@ code = '''
     // we should be able to read the version using lfs_fs_stat
     struct lfs_fsinfo fsinfo;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFSP_DISK_VERSION_MINOR);
+    assert(fsinfo.disk_version == LFSP_DISK_VERSION);
 
     // can we list the files?
     lfs_dir_t dir;
@@ -272,7 +272,7 @@ code = '''
     // we should be able to read the version using lfs_fs_stat
     struct lfs_fsinfo fsinfo;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFSP_DISK_VERSION_MINOR);
+    assert(fsinfo.disk_version == LFSP_DISK_VERSION);
 
     // can we list the directories?
     lfs_dir_t dir;
@@ -369,7 +369,7 @@ code = '''
     // we should be able to read the version using lfs_fs_stat
     struct lfs_fsinfo fsinfo;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFSP_DISK_VERSION_MINOR);
+    assert(fsinfo.disk_version == LFSP_DISK_VERSION);
 
     // write another COUNT/2 dirs
     for (lfs_size_t i = COUNT/2; i < COUNT; i++) {
@@ -451,7 +451,7 @@ code = '''
     // we should be able to read the version using lfs_fs_stat
     struct lfs_fsinfo fsinfo;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFSP_DISK_VERSION_MINOR);
+    assert(fsinfo.disk_version == LFSP_DISK_VERSION);
 
     // write half COUNT files
     prng = 42;
@@ -573,7 +573,7 @@ code = '''
     // we should be able to read the version using lfs_fs_stat
     struct lfs_fsinfo fsinfo;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFSP_DISK_VERSION_MINOR);
+    assert(fsinfo.disk_version == LFSP_DISK_VERSION);
 
     // write half COUNT files
     prng = 42;
@@ -1358,7 +1358,7 @@ code = '''
 
     struct lfs_fsinfo fsinfo;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR-1);
+    assert(fsinfo.disk_version == LFS_DISK_VERSION-1);
 
     lfs_file_open(&lfs, &file, "test", LFS_O_RDONLY) => 0;
     uint8_t buffer[8];
@@ -1368,7 +1368,7 @@ code = '''
 
     // minor version should be unchanged
     lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR-1);
+    assert(fsinfo.disk_version == LFS_DISK_VERSION-1);
 
     lfs_unmount(&lfs) => 0;
 
@@ -1376,7 +1376,7 @@ code = '''
     lfs_mount(&lfs, cfg) => 0;
 
     lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR-1);
+    assert(fsinfo.disk_version == LFS_DISK_VERSION-1);
 
     lfs_file_open(&lfs, &file, "test", LFS_O_WRONLY | LFS_O_TRUNC) => 0;
     lfs_file_write(&lfs, &file, "teeeeest", 8) => 8;
@@ -1384,7 +1384,7 @@ code = '''
 
     // minor version should be changed
     lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
+    assert(fsinfo.disk_version == LFS_DISK_VERSION);
 
     lfs_unmount(&lfs) => 0;
 
@@ -1393,7 +1393,7 @@ code = '''
 
     // minor version should have changed
     lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
+    assert(fsinfo.disk_version == LFS_DISK_VERSION);
 
     lfs_file_open(&lfs, &file, "test", LFS_O_RDONLY) => 0;
     lfs_file_read(&lfs, &file, buffer, 8) => 8;
@@ -1402,7 +1402,7 @@ code = '''
 
     // yep, still changed
     lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
+    assert(fsinfo.disk_version == LFS_DISK_VERSION);
 
     lfs_unmount(&lfs) => 0;
 '''

--- a/tests/test_compat.toml
+++ b/tests/test_compat.toml
@@ -25,11 +25,16 @@ code = '''
 #define LFSP_VERSION LFS_VERSION
 #define LFSP_VERSION_MAJOR LFS_VERSION_MAJOR
 #define LFSP_VERSION_MINOR LFS_VERSION_MINOR
+#define LFSP_DISK_VERSION LFS_DISK_VERSION
+#define LFSP_DISK_VERSION_MAJOR LFS_DISK_VERSION_MAJOR
+#define LFSP_DISK_VERSION_MINOR LFS_DISK_VERSION_MINOR
 #define lfsp_t lfs_t
 #define lfsp_config lfs_config
 #define lfsp_format lfs_format
 #define lfsp_mount lfs_mount
 #define lfsp_unmount lfs_unmount
+#define lfsp_fsinfo lfs_fsinfo
+#define lfsp_fs_stat lfs_fs_stat
 #define lfsp_dir_t lfs_dir_t
 #define lfsp_info lfs_info
 #define LFSP_TYPE_REG LFS_TYPE_REG
@@ -74,6 +79,12 @@ code = '''
     // now test the new mount
     lfs_t lfs;
     lfs_mount(&lfs, cfg) => 0;
+
+    // we should be able to read the version using lfs_fs_stat
+    struct lfs_fsinfo fsinfo;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFSP_DISK_VERSION_MINOR);
+
     lfs_unmount(&lfs) => 0;
 '''
 
@@ -101,6 +112,11 @@ code = '''
     // mount the new version
     lfs_t lfs;
     lfs_mount(&lfs, cfg) => 0;
+
+    // we should be able to read the version using lfs_fs_stat
+    struct lfs_fsinfo fsinfo;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFSP_DISK_VERSION_MINOR);
 
     // can we list the directories?
     lfs_dir_t dir;
@@ -165,6 +181,11 @@ code = '''
     // mount the new version
     lfs_t lfs;
     lfs_mount(&lfs, cfg) => 0;
+
+    // we should be able to read the version using lfs_fs_stat
+    struct lfs_fsinfo fsinfo;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFSP_DISK_VERSION_MINOR);
 
     // can we list the files?
     lfs_dir_t dir;
@@ -250,6 +271,11 @@ code = '''
     // mount the new version
     lfs_t lfs;
     lfs_mount(&lfs, cfg) => 0;
+
+    // we should be able to read the version using lfs_fs_stat
+    struct lfs_fsinfo fsinfo;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFSP_DISK_VERSION_MINOR);
 
     // can we list the directories?
     lfs_dir_t dir;
@@ -343,6 +369,11 @@ code = '''
     lfs_t lfs;
     lfs_mount(&lfs, cfg) => 0;
 
+    // we should be able to read the version using lfs_fs_stat
+    struct lfs_fsinfo fsinfo;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFSP_DISK_VERSION_MINOR);
+
     // write another COUNT/2 dirs
     for (lfs_size_t i = COUNT/2; i < COUNT; i++) {
         char name[8];
@@ -419,6 +450,11 @@ code = '''
     // mount the new version
     lfs_t lfs;
     lfs_mount(&lfs, cfg) => 0;
+
+    // we should be able to read the version using lfs_fs_stat
+    struct lfs_fsinfo fsinfo;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFSP_DISK_VERSION_MINOR);
 
     // write half COUNT files
     prng = 42;
@@ -537,6 +573,11 @@ code = '''
     lfs_t lfs;
     lfs_mount(&lfs, cfg) => 0;
 
+    // we should be able to read the version using lfs_fs_stat
+    struct lfs_fsinfo fsinfo;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFSP_DISK_VERSION_MINOR);
+
     // write half COUNT files
     prng = 42;
     for (lfs_size_t i = 0; i < COUNT; i++) {
@@ -651,6 +692,12 @@ code = '''
     memcpy(&cfgp, cfg, sizeof(cfgp));
     lfsp_t lfsp;
     lfsp_mount(&lfsp, &cfgp) => 0;
+
+    // we should be able to read the version using lfs_fs_stat
+    struct lfsp_fsinfo fsinfo;
+    lfsp_fs_stat(&lfsp, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
+
     lfsp_unmount(&lfsp) => 0;
 '''
 
@@ -678,6 +725,11 @@ code = '''
     memcpy(&cfgp, cfg, sizeof(cfgp));
     lfsp_t lfsp;
     lfsp_mount(&lfsp, &cfgp) => 0;
+
+    // we should be able to read the version using lfs_fs_stat
+    struct lfs_fsinfo fsinfo;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
 
     // can we list the directories?
     lfsp_dir_t dir;
@@ -742,6 +794,11 @@ code = '''
     memcpy(&cfgp, cfg, sizeof(cfgp));
     lfsp_t lfsp;
     lfsp_mount(&lfsp, &cfgp) => 0;
+
+    // we should be able to read the version using lfs_fs_stat
+    struct lfsp_fsinfo fsinfo;
+    lfsp_fs_stat(&lfsp, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
 
     // can we list the files?
     lfsp_dir_t dir;
@@ -827,6 +884,11 @@ code = '''
     memcpy(&cfgp, cfg, sizeof(cfgp));
     lfsp_t lfsp;
     lfsp_mount(&lfsp, &cfgp) => 0;
+
+    // we should be able to read the version using lfs_fs_stat
+    struct lfsp_fsinfo fsinfo;
+    lfsp_fs_stat(&lfsp, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
 
     // can we list the directories?
     lfsp_dir_t dir;
@@ -920,6 +982,11 @@ code = '''
     lfsp_t lfsp;
     lfsp_mount(&lfsp, &cfgp) => 0;
 
+    // we should be able to read the version using lfs_fs_stat
+    struct lfsp_fsinfo fsinfo;
+    lfsp_fs_stat(&lfsp, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
+
     // write another COUNT/2 dirs
     for (lfs_size_t i = COUNT/2; i < COUNT; i++) {
         char name[8];
@@ -996,6 +1063,11 @@ code = '''
     memcpy(&cfgp, cfg, sizeof(cfgp));
     lfsp_t lfsp;
     lfsp_mount(&lfsp, &cfgp) => 0;
+
+    // we should be able to read the version using lfs_fs_stat
+    struct lfsp_fsinfo fsinfo;
+    lfsp_fs_stat(&lfsp, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
 
     // write half COUNT files
     prng = 42;
@@ -1113,6 +1185,11 @@ code = '''
     memcpy(&cfgp, cfg, sizeof(cfgp));
     lfsp_t lfsp;
     lfsp_mount(&lfsp, &cfgp) => 0;
+
+    // we should be able to read the version using lfs_fs_stat
+    struct lfsp_fsinfo fsinfo;
+    lfsp_fs_stat(&lfsp, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
 
     // write half COUNT files
     prng = 42;
@@ -1316,45 +1393,54 @@ code = '''
 
     // mount should still work
     lfs_mount(&lfs, cfg) => 0;
+
+    struct lfs_fsinfo fsinfo;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR-1);
+
     lfs_file_open(&lfs, &file, "test", LFS_O_RDONLY) => 0;
     uint8_t buffer[8];
     lfs_file_read(&lfs, &file, buffer, 8) => 8;
     assert(memcmp(buffer, "testtest", 8) == 0);
     lfs_file_close(&lfs, &file) => 0;
+
+    // minor version should be unchanged
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR-1);
+
     lfs_unmount(&lfs) => 0;
 
     // if we write, we need to bump the minor version
     lfs_mount(&lfs, cfg) => 0;
+
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR-1);
+
     lfs_file_open(&lfs, &file, "test", LFS_O_WRONLY | LFS_O_TRUNC) => 0;
     lfs_file_write(&lfs, &file, "teeeeest", 8) => 8;
     lfs_file_close(&lfs, &file) => 0;
 
-    // minor version should have changed
-    lfs_dir_fetch(&lfs, &mdir, (lfs_block_t[2]){0, 1}) => 0;
-    lfs_dir_get(&lfs, &mdir, LFS_MKTAG(0x7ff, 0x3ff, 0),
-            LFS_MKTAG(LFS_TYPE_INLINESTRUCT, 0, sizeof(superblock)),
-            &superblock)
-            => LFS_MKTAG(LFS_TYPE_INLINESTRUCT, 0, sizeof(superblock));
-    lfs_superblock_fromle32(&superblock);
-    assert((superblock.version >> 16) & 0xffff == LFS_DISK_VERSION_MAJOR);
-    assert((superblock.version >>  0) & 0xffff == LFS_DISK_VERSION_MINOR);
+    // minor version should be changed
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
+
     lfs_unmount(&lfs) => 0;
 
     // and of course mount should still work
     lfs_mount(&lfs, cfg) => 0;
+
+    // minor version should have changed
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
+
     lfs_file_open(&lfs, &file, "test", LFS_O_RDONLY) => 0;
     lfs_file_read(&lfs, &file, buffer, 8) => 8;
     assert(memcmp(buffer, "teeeeest", 8) == 0);
     lfs_file_close(&lfs, &file) => 0;
 
-    // minor version should have changed
-    lfs_dir_fetch(&lfs, &mdir, (lfs_block_t[2]){0, 1}) => 0;
-    lfs_dir_get(&lfs, &mdir, LFS_MKTAG(0x7ff, 0x3ff, 0),
-            LFS_MKTAG(LFS_TYPE_INLINESTRUCT, 0, sizeof(superblock)),
-            &superblock)
-            => LFS_MKTAG(LFS_TYPE_INLINESTRUCT, 0, sizeof(superblock));
-    lfs_superblock_fromle32(&superblock);
-    assert((superblock.version >> 16) & 0xffff == LFS_DISK_VERSION_MAJOR);
-    assert((superblock.version >>  0) & 0xffff == LFS_DISK_VERSION_MINOR);
+    // yep, still changed
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
+
     lfs_unmount(&lfs) => 0;
 '''

--- a/tests/test_compat.toml
+++ b/tests/test_compat.toml
@@ -690,11 +690,6 @@ code = '''
     lfsp_t lfsp;
     lfsp_mount(&lfsp, &cfgp) => 0;
 
-    // we should be able to read the version using lfs_fs_stat
-    struct lfsp_fsinfo fsinfo;
-    lfsp_fs_stat(&lfsp, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
-
     lfsp_unmount(&lfsp) => 0;
 '''
 
@@ -722,11 +717,6 @@ code = '''
     memcpy(&cfgp, cfg, sizeof(cfgp));
     lfsp_t lfsp;
     lfsp_mount(&lfsp, &cfgp) => 0;
-
-    // we should be able to read the version using lfs_fs_stat
-    struct lfs_fsinfo fsinfo;
-    lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
 
     // can we list the directories?
     lfsp_dir_t dir;
@@ -791,11 +781,6 @@ code = '''
     memcpy(&cfgp, cfg, sizeof(cfgp));
     lfsp_t lfsp;
     lfsp_mount(&lfsp, &cfgp) => 0;
-
-    // we should be able to read the version using lfs_fs_stat
-    struct lfsp_fsinfo fsinfo;
-    lfsp_fs_stat(&lfsp, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
 
     // can we list the files?
     lfsp_dir_t dir;
@@ -881,11 +866,6 @@ code = '''
     memcpy(&cfgp, cfg, sizeof(cfgp));
     lfsp_t lfsp;
     lfsp_mount(&lfsp, &cfgp) => 0;
-
-    // we should be able to read the version using lfs_fs_stat
-    struct lfsp_fsinfo fsinfo;
-    lfsp_fs_stat(&lfsp, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
 
     // can we list the directories?
     lfsp_dir_t dir;
@@ -979,11 +959,6 @@ code = '''
     lfsp_t lfsp;
     lfsp_mount(&lfsp, &cfgp) => 0;
 
-    // we should be able to read the version using lfs_fs_stat
-    struct lfsp_fsinfo fsinfo;
-    lfsp_fs_stat(&lfsp, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
-
     // write another COUNT/2 dirs
     for (lfs_size_t i = COUNT/2; i < COUNT; i++) {
         char name[8];
@@ -1060,11 +1035,6 @@ code = '''
     memcpy(&cfgp, cfg, sizeof(cfgp));
     lfsp_t lfsp;
     lfsp_mount(&lfsp, &cfgp) => 0;
-
-    // we should be able to read the version using lfs_fs_stat
-    struct lfsp_fsinfo fsinfo;
-    lfsp_fs_stat(&lfsp, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
 
     // write half COUNT files
     prng = 42;
@@ -1182,11 +1152,6 @@ code = '''
     memcpy(&cfgp, cfg, sizeof(cfgp));
     lfsp_t lfsp;
     lfsp_mount(&lfsp, &cfgp) => 0;
-
-    // we should be able to read the version using lfs_fs_stat
-    struct lfsp_fsinfo fsinfo;
-    lfsp_fs_stat(&lfsp, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
 
     // write half COUNT files
     prng = 42;

--- a/tests/test_compat.toml
+++ b/tests/test_compat.toml
@@ -22,9 +22,6 @@ code = '''
 #define STRINGIZE_(x) #x
 #include STRINGIZE(LFSP)
 #else
-#define LFSP_VERSION LFS_VERSION
-#define LFSP_VERSION_MAJOR LFS_VERSION_MAJOR
-#define LFSP_VERSION_MINOR LFS_VERSION_MINOR
 #define LFSP_DISK_VERSION LFS_DISK_VERSION
 #define LFSP_DISK_VERSION_MAJOR LFS_DISK_VERSION_MAJOR
 #define LFSP_DISK_VERSION_MINOR LFS_DISK_VERSION_MINOR
@@ -63,7 +60,7 @@ code = '''
 
 # test we can mount in a new version
 [cases.test_compat_forward_mount]
-if = 'LFS_VERSION_MAJOR == LFSP_VERSION_MAJOR'
+if = 'LFS_DISK_VERSION_MAJOR == LFSP_DISK_VERSION_MAJOR'
 code = '''
     // create the previous version
     struct lfsp_config cfgp;
@@ -91,7 +88,7 @@ code = '''
 # test we can read dirs in a new version
 [cases.test_compat_forward_read_dirs]
 defines.COUNT = 5
-if = 'LFS_VERSION_MAJOR == LFSP_VERSION_MAJOR'
+if = 'LFS_DISK_VERSION_MAJOR == LFSP_DISK_VERSION_MAJOR'
 code = '''
     // create the previous version
     struct lfsp_config cfgp;
@@ -148,7 +145,7 @@ code = '''
 defines.COUNT = 5
 defines.SIZE = [4, 32, 512, 8192]
 defines.CHUNK = 4
-if = 'LFS_VERSION_MAJOR == LFSP_VERSION_MAJOR'
+if = 'LFS_DISK_VERSION_MAJOR == LFSP_DISK_VERSION_MAJOR'
 code = '''
     // create the previous version
     struct lfsp_config cfgp;
@@ -235,7 +232,7 @@ code = '''
 defines.COUNT = 5
 defines.SIZE = [4, 32, 512, 8192]
 defines.CHUNK = 4
-if = 'LFS_VERSION_MAJOR == LFSP_VERSION_MAJOR'
+if = 'LFS_DISK_VERSION_MAJOR == LFSP_DISK_VERSION_MAJOR'
 code = '''
     // create the previous version
     struct lfsp_config cfgp;
@@ -347,7 +344,7 @@ code = '''
 # test we can write dirs in a new version
 [cases.test_compat_forward_write_dirs]
 defines.COUNT = 10
-if = 'LFS_VERSION_MAJOR == LFSP_VERSION_MAJOR'
+if = 'LFS_DISK_VERSION_MAJOR == LFSP_DISK_VERSION_MAJOR'
 code = '''
     // create the previous version
     struct lfsp_config cfgp;
@@ -411,7 +408,7 @@ code = '''
 defines.COUNT = 5
 defines.SIZE = [4, 32, 512, 8192]
 defines.CHUNK = 2
-if = 'LFS_VERSION_MAJOR == LFSP_VERSION_MAJOR'
+if = 'LFS_DISK_VERSION_MAJOR == LFSP_DISK_VERSION_MAJOR'
 code = '''
     // create the previous version
     struct lfsp_config cfgp;
@@ -530,7 +527,7 @@ code = '''
 defines.COUNT = 5
 defines.SIZE = [4, 32, 512, 8192]
 defines.CHUNK = 2
-if = 'LFS_VERSION_MAJOR == LFSP_VERSION_MAJOR'
+if = 'LFS_DISK_VERSION_MAJOR == LFSP_DISK_VERSION_MAJOR'
 code = '''
     // create the previous version
     struct lfsp_config cfgp;
@@ -677,7 +674,7 @@ code = '''
 
 # test we can mount in an old version
 [cases.test_compat_backward_mount]
-if = 'LFS_VERSION == LFSP_VERSION'
+if = 'LFS_DISK_VERSION == LFSP_DISK_VERSION'
 code = '''
     // create the new version
     lfs_t lfs;
@@ -704,7 +701,7 @@ code = '''
 # test we can read dirs in an old version
 [cases.test_compat_backward_read_dirs]
 defines.COUNT = 5
-if = 'LFS_VERSION == LFSP_VERSION'
+if = 'LFS_DISK_VERSION == LFSP_DISK_VERSION'
 code = '''
     // create the new version
     lfs_t lfs;
@@ -761,7 +758,7 @@ code = '''
 defines.COUNT = 5
 defines.SIZE = [4, 32, 512, 8192]
 defines.CHUNK = 4
-if = 'LFS_VERSION == LFSP_VERSION'
+if = 'LFS_DISK_VERSION == LFSP_DISK_VERSION'
 code = '''
     // create the new version
     lfs_t lfs;
@@ -848,7 +845,7 @@ code = '''
 defines.COUNT = 5
 defines.SIZE = [4, 32, 512, 8192]
 defines.CHUNK = 4
-if = 'LFS_VERSION == LFSP_VERSION'
+if = 'LFS_DISK_VERSION == LFSP_DISK_VERSION'
 code = '''
     // create the new version
     lfs_t lfs;
@@ -960,7 +957,7 @@ code = '''
 # test we can write dirs in an old version
 [cases.test_compat_backward_write_dirs]
 defines.COUNT = 10
-if = 'LFS_VERSION == LFSP_VERSION'
+if = 'LFS_DISK_VERSION == LFSP_DISK_VERSION'
 code = '''
     // create the new version
     lfs_t lfs;
@@ -1024,7 +1021,7 @@ code = '''
 defines.COUNT = 5
 defines.SIZE = [4, 32, 512, 8192]
 defines.CHUNK = 2
-if = 'LFS_VERSION == LFSP_VERSION'
+if = 'LFS_DISK_VERSION == LFSP_DISK_VERSION'
 code = '''
     // create the previous version
     lfs_t lfs;
@@ -1143,7 +1140,7 @@ code = '''
 defines.COUNT = 5
 defines.SIZE = [4, 32, 512, 8192]
 defines.CHUNK = 2
-if = 'LFS_VERSION == LFSP_VERSION'
+if = 'LFS_DISK_VERSION == LFSP_DISK_VERSION'
 code = '''
     // create the previous version
     lfs_t lfs;

--- a/tests/test_superblocks.toml
+++ b/tests/test_superblocks.toml
@@ -45,7 +45,7 @@ code = '''
 
     struct lfs_fsinfo fsinfo;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
+    assert(fsinfo.disk_version == LFS_DISK_VERSION);
     assert(fsinfo.block_usage > 0 && fsinfo.block_usage < BLOCK_COUNT);
     assert(fsinfo.name_max == LFS_NAME_MAX);
     assert(fsinfo.file_max == LFS_FILE_MAX);
@@ -73,7 +73,7 @@ code = '''
 
     struct lfs_fsinfo fsinfo;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
-    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
+    assert(fsinfo.disk_version == LFS_DISK_VERSION);
     assert(fsinfo.block_usage > 0 && fsinfo.block_usage < BLOCK_COUNT);
     assert(fsinfo.name_max == TWEAKED_NAME_MAX);
     assert(fsinfo.file_max == TWEAKED_FILE_MAX);

--- a/tests/test_superblocks.toml
+++ b/tests/test_superblocks.toml
@@ -46,7 +46,6 @@ code = '''
     struct lfs_fsinfo fsinfo;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
     assert(fsinfo.disk_version == LFS_DISK_VERSION);
-    assert(fsinfo.block_usage > 0 && fsinfo.block_usage < BLOCK_COUNT);
     assert(fsinfo.name_max == LFS_NAME_MAX);
     assert(fsinfo.file_max == LFS_FILE_MAX);
     assert(fsinfo.attr_max == LFS_ATTR_MAX);
@@ -74,7 +73,6 @@ code = '''
     struct lfs_fsinfo fsinfo;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
     assert(fsinfo.disk_version == LFS_DISK_VERSION);
-    assert(fsinfo.block_usage > 0 && fsinfo.block_usage < BLOCK_COUNT);
     assert(fsinfo.name_max == TWEAKED_NAME_MAX);
     assert(fsinfo.file_max == TWEAKED_FILE_MAX);
     assert(fsinfo.attr_max == TWEAKED_ATTR_MAX);

--- a/tests/test_superblocks.toml
+++ b/tests/test_superblocks.toml
@@ -34,6 +34,54 @@ code = '''
     lfs_mount(&lfs, cfg) => LFS_ERR_CORRUPT;
 '''
 
+# test we can read superblock info through lfs_fs_stat
+[cases.test_superblocks_stat]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+
+    // test we can mount and read fsinfo
+    lfs_mount(&lfs, cfg) => 0;
+
+    struct lfs_fsinfo fsinfo;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
+    assert(fsinfo.block_usage > 0 && fsinfo.block_usage < BLOCK_COUNT);
+    assert(fsinfo.name_max == LFS_NAME_MAX);
+    assert(fsinfo.file_max == LFS_FILE_MAX);
+    assert(fsinfo.attr_max == LFS_ATTR_MAX);
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+[cases.test_superblocks_stat_tweaked]
+defines.TWEAKED_NAME_MAX = 63
+defines.TWEAKED_FILE_MAX = '(1 << 16)-1'
+defines.TWEAKED_ATTR_MAX = 512
+code = '''
+    // create filesystem with tweaked params
+    struct lfs_config tweaked_cfg = *cfg;
+    tweaked_cfg.name_max = TWEAKED_NAME_MAX;
+    tweaked_cfg.file_max = TWEAKED_FILE_MAX;
+    tweaked_cfg.attr_max = TWEAKED_ATTR_MAX;
+
+    lfs_t lfs;
+    lfs_format(&lfs, &tweaked_cfg) => 0;
+
+    // test we can mount and read these params with the original config
+    lfs_mount(&lfs, cfg) => 0;
+
+    struct lfs_fsinfo fsinfo;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.minor_version == LFS_DISK_VERSION_MINOR);
+    assert(fsinfo.block_usage > 0 && fsinfo.block_usage < BLOCK_COUNT);
+    assert(fsinfo.name_max == TWEAKED_NAME_MAX);
+    assert(fsinfo.file_max == TWEAKED_FILE_MAX);
+    assert(fsinfo.attr_max == TWEAKED_ATTR_MAX);
+
+    lfs_unmount(&lfs) => 0;
+'''
+
 # expanding superblock
 [cases.test_superblocks_expand]
 defines.BLOCK_CYCLES = [32, 33, 1]


### PR DESCRIPTION
This is more-or-less cherry-picked from https://github.com/littlefs-project/littlefs/pull/753, which is paused for now.

`lfs_fs_stat` introduces a way to access some of the littlefs-specific status/configuration that hasn't been available yet. The intention is to be analogous the POSIX [statvfs](https://linux.die.net/man/2/statvfs):

``` c
// Find on-disk info about the filesystem
//
// Fills out the fsinfo structure based on the filesystem found on-disk.
// Returns a negative error code on failure.
int lfs_fs_stat(lfs_t *lfs, struct lfs_fsinfo *fsinfo);
```

The immediate benefit of this function is a way to get the minor version on disk, which @TjoBitDk noted was oddly missing in the recent release. This should resolve https://github.com/littlefs-project/littlefs/issues/826.

Currently `lfs_fs_stat` includes:

- disk_version - on-disk version
- name_max - configurable name limit
- file_max - configurable file limit
- attr_max - configurable attr limit

These are currently the only configuration operations that need to be written to disk. Other configuration is either needed to mount, such as block_size, or does not change the on-disk representation, such as read/prog_size.

~This also includes the current block usage, which is common in other filesystems, though a more expensive to find in littlefs. I figure it's not unreasonable to make lfs_fs_stat no worse than block allocation, hopefully this isn't a mistake. It may be worth caching the current usage after the most recent lookahead scan.~ EDIT: Removed due to concerns about runtime cost. May add back to fsinfo in the future.

More configuration may be added to this struct in the future.