### PR TITLE
added basic support for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(littlefs)
+
+target_sources(littlefs PUBLIC
+        lfs.c
+        lfs_util.c)
+
+target_include_directories(littlefs PUBLIC
+        .)


### PR DESCRIPTION
A lot of projects (for ex. pico-sdk) use cmake as their compilation helper. I needed to include this in my Pico project, so here it is.

It becomes trivial to use (and also add compile flags). Example:
```cmake
add_subdirectory(littlefs)
target_compile_definitions(littlefs PUBLIC LFS_THREADSAFE)
```