### PR TITLE
init disk instance before use

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -878,6 +878,8 @@ static int lfs_dir_traverse(lfs_t *lfs,
     lfs_tag_t tag;
     const void *buffer;
     struct lfs_diskoff disk;
+    disk.block = 0;
+    disk.off = 0;
     while (true) {
         {
             if (off+lfs_tag_dsize(ptag) < dir->off) {


### PR DESCRIPTION
under some compilers (e.g. MSVC) the variable may not be init to 0 which can lead to a crash at line 918