### PR TITLE
Add lfs_fs_gc to enable proactive finding of free blocks

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -662,7 +662,9 @@ static int lfs_alloc(lfs_t *lfs, lfs_block_t *block) {
 }
 
 int lfs_find_free_blocks(lfs_t *lfs){
-    lfs->free.off = (lfs->free.off + lfs->free.size)
+    // Move free offset at the first unused block (lfs->free.i)
+    // lfs->free.i is equal lfs->free.size when all blocks are used
+    lfs->free.off = (lfs->free.off + lfs->free.i)
         % lfs->block_count;
     lfs->free.size = lfs_min(8*lfs->cfg->lookahead_size, lfs->free.ack);
     lfs->free.i = 0;

--- a/lfs.c
+++ b/lfs.c
@@ -623,7 +623,7 @@ static void lfs_alloc_drop(lfs_t *lfs) {
 }
 
 #ifndef LFS_READONLY
-static int lfs_fs_rawfindfreeblocks(lfs_t *lfs) {
+static int lfs_fs_rawgc(lfs_t *lfs) {
     // Move free offset at the first unused block (lfs->free.i)
     // lfs->free.i is equal lfs->free.size when all blocks are used
     lfs->free.off = (lfs->free.off + lfs->free.i) % lfs->block_count;
@@ -674,7 +674,7 @@ static int lfs_alloc(lfs_t *lfs, lfs_block_t *block) {
             return LFS_ERR_NOSPC;
         }
 
-        int err = lfs_fs_rawfindfreeblocks(lfs);
+        int err = lfs_fs_rawgc(lfs);
         if(err) {
             return err;
         }
@@ -6251,16 +6251,16 @@ int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void *, lfs_block_t), void *data) {
 }
 
 #ifndef LFS_READONLY
-int lfs_fs_findfreeblocks(lfs_t *lfs) {
+int lfs_fs_gc(lfs_t *lfs) {
     int err = LFS_LOCK(lfs->cfg);
     if (err) {
         return err;
     }
-    LFS_TRACE("lfs_fs_findfreeblocks(%p)", (void*)lfs);
+    LFS_TRACE("lfs_fs_gc(%p)", (void*)lfs);
 
-    err = lfs_fs_rawfindfreeblocks(lfs);
+    err = lfs_fs_rawgc(lfs);
 
-    LFS_TRACE("lfs_fs_findfreeblocks -> %d", err);
+    LFS_TRACE("lfs_fs_gc -> %d", err);
     LFS_UNLOCK(lfs->cfg);
     return err;
 }

--- a/lfs.c
+++ b/lfs.c
@@ -654,19 +654,26 @@ static int lfs_alloc(lfs_t *lfs, lfs_block_t *block) {
             return LFS_ERR_NOSPC;
         }
 
-        lfs->free.off = (lfs->free.off + lfs->free.size)
-                % lfs->block_count;
-        lfs->free.size = lfs_min(8*lfs->cfg->lookahead_size, lfs->free.ack);
-        lfs->free.i = 0;
-
-        // find mask of free blocks from tree
-        memset(lfs->free.buffer, 0, lfs->cfg->lookahead_size);
-        int err = lfs_fs_rawtraverse(lfs, lfs_alloc_lookahead, lfs, true);
-        if (err) {
-            lfs_alloc_drop(lfs);
+        int err = lfs_find_free_blocks(lfs);
+        if(err) {
             return err;
         }
     }
+}
+
+int lfs_find_free_blocks(lfs_t *lfs){
+    lfs->free.off = (lfs->free.off + lfs->free.size)
+        % lfs->block_count;
+    lfs->free.size = lfs_min(8*lfs->cfg->lookahead_size, lfs->free.ack);
+    lfs->free.i = 0;
+
+    // find mask of free blocks from tree
+    memset(lfs->free.buffer, 0, lfs->cfg->lookahead_size);
+    int const err = lfs_fs_rawtraverse(lfs, lfs_alloc_lookahead, lfs, true);
+    if (err) {
+        lfs_alloc_drop(lfs);
+    }
+    return err;
 }
 #endif
 

--- a/lfs.h
+++ b/lfs.h
@@ -712,6 +712,10 @@ lfs_ssize_t lfs_fs_size(lfs_t *lfs);
 // Returns a negative error code on failure.
 int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 
+// Use Traverse function and try to find free blocks. LittleFS free blocks search is unpredictable.
+// Search is costly operation which may delay write. In realtime write scenarios can be better to find them before a write.
+int lfs_find_free_blocks(lfs_t *lfs);
+
 #ifndef LFS_READONLY
 // Attempt to make the filesystem consistent and ready for writing
 //

--- a/lfs.h
+++ b/lfs.h
@@ -712,9 +712,12 @@ lfs_ssize_t lfs_fs_size(lfs_t *lfs);
 // Returns a negative error code on failure.
 int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 
-// Use Traverse function and try to find free blocks. LittleFS free blocks search is unpredictable.
-// Search is costly operation which may delay write. In realtime write scenarios can be better to find them before a write.
-int lfs_find_free_blocks(lfs_t *lfs);
+// Use Traverse function and try to find free blocks. LittleFS free blocks
+// search is unpredictable.
+//
+// Search is costly operation which may delay write. In realtime write
+// scenarios can be better to find them before a write.
+int lfs_fs_findfreeblocks(lfs_t *lfs);
 
 #ifndef LFS_READONLY
 // Attempt to make the filesystem consistent and ready for writing

--- a/lfs.h
+++ b/lfs.h
@@ -712,12 +712,17 @@ lfs_ssize_t lfs_fs_size(lfs_t *lfs);
 // Returns a negative error code on failure.
 int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 
-// Use Traverse function and try to find free blocks. LittleFS free blocks
-// search is unpredictable.
+// Attempt to proactively find free blocks
 //
-// Search is costly operation which may delay write. In realtime write
-// scenarios can be better to find them before a write.
-int lfs_fs_findfreeblocks(lfs_t *lfs);
+// Calling this function is not required, but may allowing the offloading of
+// the expensive block allocation scan to a less time-critical code path.
+//
+// Note: littlefs currently does not persist any found free blocks to disk.
+// This may change in the future.
+//
+// Returns a negative error code on failure. Finding no free blocks is
+// not an error.
+int lfs_fs_gc(lfs_t *lfs);
 
 #ifndef LFS_READONLY
 // Attempt to make the filesystem consistent and ready for writing

--- a/tests/test_alloc.toml
+++ b/tests/test_alloc.toml
@@ -6,6 +6,7 @@ if = 'BLOCK_CYCLES == -1'
 [cases.test_alloc_parallel]
 defines.FILES = 3
 defines.SIZE = '(((BLOCK_SIZE-8)*(BLOCK_COUNT-6)) / FILES)'
+defines.GC = [false, true]
 code = '''
     const char *names[] = {"bacon", "eggs", "pancakes"};
     lfs_file_t files[FILES];
@@ -24,6 +25,9 @@ code = '''
                 LFS_O_WRONLY | LFS_O_CREAT | LFS_O_APPEND) => 0;
     }
     for (int n = 0; n < FILES; n++) {
+        if (GC) {
+            lfs_fs_findfreeblocks(&lfs) => 0;
+        }
         size_t size = strlen(names[n]);
         for (lfs_size_t i = 0; i < SIZE; i += size) {
             lfs_file_write(&lfs, &files[n], names[n], size) => size;
@@ -55,6 +59,7 @@ code = '''
 [cases.test_alloc_serial]
 defines.FILES = 3
 defines.SIZE = '(((BLOCK_SIZE-8)*(BLOCK_COUNT-6)) / FILES)'
+defines.GC = [false, true]
 code = '''
     const char *names[] = {"bacon", "eggs", "pancakes"};
 
@@ -75,6 +80,9 @@ code = '''
         uint8_t buffer[1024];
         memcpy(buffer, names[n], size);
         for (int i = 0; i < SIZE; i += size) {
+            if (GC) {
+                lfs_fs_findfreeblocks(&lfs) => 0;
+            }
             lfs_file_write(&lfs, &file, buffer, size) => size;
         }
         lfs_file_close(&lfs, &file) => 0;
@@ -247,6 +255,9 @@ code = '''
     }
     res => LFS_ERR_NOSPC;
 
+    // note that lfs_fs_findfreeblocks should not error here
+    lfs_fs_findfreeblocks(&lfs) => 0;
+
     lfs_file_close(&lfs, &file) => 0;
     lfs_unmount(&lfs) => 0;
 
@@ -298,6 +309,9 @@ code = '''
     }
     res => LFS_ERR_NOSPC;
 
+    // note that lfs_fs_findfreeblocks should not error here
+    lfs_fs_findfreeblocks(&lfs) => 0;
+
     lfs_file_close(&lfs, &file) => 0;
     lfs_unmount(&lfs) => 0;
 
@@ -337,6 +351,8 @@ code = '''
         count += 1;
     }
     err => LFS_ERR_NOSPC;
+    // note that lfs_fs_findfreeblocks should not error here
+    lfs_fs_findfreeblocks(&lfs) => 0;
     lfs_file_close(&lfs, &file) => 0;
 
     lfs_remove(&lfs, "exhaustion") => 0;
@@ -435,6 +451,8 @@ code = '''
             break;
         }
     }
+    // note that lfs_fs_findfreeblocks should not error here
+    lfs_fs_findfreeblocks(&lfs) => 0;
     lfs_file_close(&lfs, &file) => 0;
 
     lfs_unmount(&lfs) => 0;

--- a/tests/test_alloc.toml
+++ b/tests/test_alloc.toml
@@ -26,7 +26,7 @@ code = '''
     }
     for (int n = 0; n < FILES; n++) {
         if (GC) {
-            lfs_fs_findfreeblocks(&lfs) => 0;
+            lfs_fs_gc(&lfs) => 0;
         }
         size_t size = strlen(names[n]);
         for (lfs_size_t i = 0; i < SIZE; i += size) {
@@ -81,7 +81,7 @@ code = '''
         memcpy(buffer, names[n], size);
         for (int i = 0; i < SIZE; i += size) {
             if (GC) {
-                lfs_fs_findfreeblocks(&lfs) => 0;
+                lfs_fs_gc(&lfs) => 0;
             }
             lfs_file_write(&lfs, &file, buffer, size) => size;
         }
@@ -255,8 +255,8 @@ code = '''
     }
     res => LFS_ERR_NOSPC;
 
-    // note that lfs_fs_findfreeblocks should not error here
-    lfs_fs_findfreeblocks(&lfs) => 0;
+    // note that lfs_fs_gc should not error here
+    lfs_fs_gc(&lfs) => 0;
 
     lfs_file_close(&lfs, &file) => 0;
     lfs_unmount(&lfs) => 0;
@@ -309,8 +309,8 @@ code = '''
     }
     res => LFS_ERR_NOSPC;
 
-    // note that lfs_fs_findfreeblocks should not error here
-    lfs_fs_findfreeblocks(&lfs) => 0;
+    // note that lfs_fs_gc should not error here
+    lfs_fs_gc(&lfs) => 0;
 
     lfs_file_close(&lfs, &file) => 0;
     lfs_unmount(&lfs) => 0;
@@ -351,8 +351,8 @@ code = '''
         count += 1;
     }
     err => LFS_ERR_NOSPC;
-    // note that lfs_fs_findfreeblocks should not error here
-    lfs_fs_findfreeblocks(&lfs) => 0;
+    // note that lfs_fs_gc should not error here
+    lfs_fs_gc(&lfs) => 0;
     lfs_file_close(&lfs, &file) => 0;
 
     lfs_remove(&lfs, "exhaustion") => 0;
@@ -451,8 +451,8 @@ code = '''
             break;
         }
     }
-    // note that lfs_fs_findfreeblocks should not error here
-    lfs_fs_findfreeblocks(&lfs) => 0;
+    // note that lfs_fs_gc should not error here
+    lfs_fs_gc(&lfs) => 0;
     lfs_file_close(&lfs, &file) => 0;
 
     lfs_unmount(&lfs) => 0;


### PR DESCRIPTION
See https://github.com/littlefs-project/littlefs/pull/610 for more info, original PR by @opilat.

This API allows users to run the internal block allocator directly, which may allow users to move the expensive block scan out of performance sensitive parts of their codebase.

It should be noted this API does not current persist the results of the block scan on disk, so calling lfs_fs_gc and then remounting does nothing. This may change in the future.

