### PR TITLE
lfs_fs_raw* functions should be static

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ CFLAGS += -fcallgraph-info=su
 CFLAGS += -g3
 CFLAGS += -I.
 CFLAGS += -std=c99 -Wall -Wextra -pedantic
+CFLAGS += -Wmissing-prototypes
 CFLAGS += -ftrack-macro-expansion=0
 ifdef DEBUG
 CFLAGS += -O0
@@ -354,6 +355,7 @@ summary-diff sizes-diff: $(OBJ) $(CI)
 
 ## Build the test-runner
 .PHONY: test-runner build-test
+test-runner build-test: CFLAGS+=-Wno-missing-prototypes
 ifndef NO_COV
 test-runner build-test: CFLAGS+=--coverage
 endif
@@ -405,6 +407,7 @@ testmarks-diff: $(TEST_CSV)
 
 ## Build the bench-runner
 .PHONY: bench-runner build-bench
+bench-runner build-bench: CFLAGS+=-Wno-missing-prototypes
 ifdef YES_COV
 bench-runner build-bench: CFLAGS+=--coverage
 endif

--- a/lfs.c
+++ b/lfs.c
@@ -4999,7 +4999,7 @@ static int lfs_fs_forceconsistency(lfs_t *lfs) {
 #endif
 
 #ifndef LFS_READONLY
-int lfs_fs_rawmkconsistent(lfs_t *lfs) {
+static int lfs_fs_rawmkconsistent(lfs_t *lfs) {
     // lfs_fs_forceconsistency does most of the work here
     int err = lfs_fs_forceconsistency(lfs);
     if (err) {
@@ -5046,7 +5046,7 @@ static lfs_ssize_t lfs_fs_rawsize(lfs_t *lfs) {
 }
 
 #ifndef LFS_READONLY
-int lfs_fs_rawgrow(lfs_t *lfs, lfs_size_t block_count) {
+static int lfs_fs_rawgrow(lfs_t *lfs, lfs_size_t block_count) {
     // shrinking is not supported
     LFS_ASSERT(block_count >= lfs->block_count);
 


### PR DESCRIPTION
Two new functions introduced in 2.6.0 (`lfs_fs_mkconsistent`, 259535ee73a792556bb16eebfbd076f467c5bdfa) and 2.8.0 (`lfs_fs_grow`, 23505fa9fa4f2d863f046c0bfad8db2ca63cfb90) have internal "raw" functions which are missing the `static` keyword.

This was causing build failures in our builds in the MicroPython project when updating to the latest LittleFS, because we're building with `-Werror,-Wmissing-prototypes,-Wmissing-declarations`. See [here](https://github.com/micropython/micropython/actions/runs/6561913228/job/17822696395) and [here](https://github.com/micropython/micropython/actions/runs/6575701921/job/17863464790) for the build output.

This PR adds the `static` keyword to these functions to fix these, similar to how all other internal functions in LittleFS are defined.