### PR TITLE
Add value-range checks for user-definable macros at compile-time

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -4112,8 +4112,8 @@ static int lfs_rawremoveattr(lfs_t *lfs, const char *path, uint8_t type) {
 #error "Invalid LFS_NAME_MAX, must be <= 1022"
 #endif
 
-#if LFS_FILE_MAX > 4294967295
-#error "Invalid LFS_FILE_MAX, must be <= 4294967295"
+#if LFS_FILE_MAX > 2147483647
+#error "Invalid LFS_FILE_MAX, must be <= 2147483647"
 #endif
 
 #if LFS_ATTR_MAX > 1022

--- a/lfs.c
+++ b/lfs.c
@@ -8,23 +8,6 @@
 #include "lfs.h"
 #include "lfs_util.h"
 
-// Configuration Sanity Check
-#if (LFS_NAME_MAX <= 0) || (LFS_NAME_MAX > 1022)
-#error "LFS_NAME_MAX must be in the range (0, 1022]"
-#endif
-
-#if (LFS_FILE_MAX <= 0) || (LFS_FILE_MAX > 4294967295)
-#error "LFS_FILE_MAX must be in the range (0, 4294967295]"
-#endif
-
-#if (LFS_FILE_MAX > 2147483647)
-#warning "LFS_FILE_MAX>2147483647; lfs_file_seek, lfs_file_size, and lfs_file_tell will not function properly."
-#endif
-
-#if (LFS_ATTR_MAX < 0) || (LFS_ATTR_MAX > 1022)
-#error "LFS_ATTR_MAX must be in the range [0, 1022]"
-#endif
-
 
 // some constants used throughout the code
 #define LFS_BLOCK_NULL ((lfs_block_t)-1)
@@ -4123,6 +4106,21 @@ static int lfs_rawremoveattr(lfs_t *lfs, const char *path, uint8_t type) {
 
 
 /// Filesystem operations ///
+
+// compile time checks, see lfs.h for why these limits exist
+#if LFS_NAME_MAX > 1022
+#error "Invalid LFS_NAME_MAX, must be <= 1022"
+#endif
+
+#if LFS_FILE_MAX > 4294967295
+#error "Invalid LFS_FILE_MAX, must be <= 4294967295"
+#endif
+
+#if LFS_ATTR_MAX > 1022
+#error "Invalid LFS_ATTR_MAX, must be <= 1022"
+#endif
+
+// common filesystem initialization
 static int lfs_init(lfs_t *lfs, const struct lfs_config *cfg) {
     lfs->cfg = cfg;
     lfs->block_count = cfg->block_count;  // May be 0

--- a/lfs.c
+++ b/lfs.c
@@ -8,6 +8,23 @@
 #include "lfs.h"
 #include "lfs_util.h"
 
+// Configuration Sanity Check
+#if (LFS_NAME_MAX <= 0) || (LFS_NAME_MAX > 1022)
+#error "LFS_NAME_MAX must be in the range (0, 1022]"
+#endif
+
+#if (LFS_FILE_MAX <= 0) || (LFS_FILE_MAX > 4294967296)
+#error "LFS_FILE_MAX must be in the range (0, 4294967296]"
+#endif
+
+#if (LFS_FILE_MAX > 2147483647)
+#warning "LFS_FILE_MAX>2147483647; lfs_file_seek, lfs_file_size, and lfs_file_tell will not function properly."
+#endif
+
+#if (LFS_ATTR_MAX < 0) || (LFS_ATTR_MAX > 1022)
+#error "LFS_ATTR_MAX must be in the range [0, 1022]"
+#endif
+
 
 // some constants used throughout the code
 #define LFS_BLOCK_NULL ((lfs_block_t)-1)

--- a/lfs.c
+++ b/lfs.c
@@ -13,8 +13,8 @@
 #error "LFS_NAME_MAX must be in the range (0, 1022]"
 #endif
 
-#if (LFS_FILE_MAX <= 0) || (LFS_FILE_MAX > 4294967296)
-#error "LFS_FILE_MAX must be in the range (0, 4294967296]"
+#if (LFS_FILE_MAX <= 0) || (LFS_FILE_MAX > 4294967295)
+#error "LFS_FILE_MAX must be in the range (0, 4294967295]"
 #endif
 
 #if (LFS_FILE_MAX > 2147483647)

--- a/lfs.h
+++ b/lfs.h
@@ -52,10 +52,8 @@ typedef uint32_t lfs_block_t;
 #endif
 
 // Maximum size of a file in bytes, may be redefined to limit to support other
-// drivers. Limited on disk to <= 4294967295. However, above 2147483647 the
-// functions lfs_file_seek, lfs_file_size, and lfs_file_tell will return
-// incorrect values due to using signed integers. Stored in superblock and
-// must be respected by other littlefs drivers.
+// drivers. Limited on disk to <= 2147483647. Stored in superblock and must be
+// respected by other littlefs drivers.
 #ifndef LFS_FILE_MAX
 #define LFS_FILE_MAX 2147483647
 #endif

--- a/lfs.h
+++ b/lfs.h
@@ -52,7 +52,7 @@ typedef uint32_t lfs_block_t;
 #endif
 
 // Maximum size of a file in bytes, may be redefined to limit to support other
-// drivers. Limited on disk to <= 4294967296. However, above 2147483647 the
+// drivers. Limited on disk to <= 4294967295. However, above 2147483647 the
 // functions lfs_file_seek, lfs_file_size, and lfs_file_tell will return
 // incorrect values due to using signed integers. Stored in superblock and
 // must be respected by other littlefs drivers.


### PR DESCRIPTION
Added some sanity check for the user-providable `#define` macro values.

This was brought up due to a bug introduced by yours truly 💅  https://github.com/jrast/littlefs-python/issues/61