### PR TITLE
Add some easier util overrides: LFS_MALLOC/FREE/CRC

### DIFF
--- a/lfs_util.c
+++ b/lfs_util.c
@@ -11,6 +11,8 @@
 #ifndef LFS_CONFIG
 
 
+// If user provides their own CRC impl we don't need this
+#ifndef LFS_CRC
 // Software CRC implementation with small lookup table
 uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size) {
     static const uint32_t rtable[16] = {
@@ -29,6 +31,7 @@ uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size) {
 
     return crc;
 }
+#endif
 
 
 #endif

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -212,7 +212,13 @@ static inline uint32_t lfs_tobe32(uint32_t a) {
 }
 
 // Calculate CRC-32 with polynomial = 0x04c11db7
+#ifdef LFS_CRC
+uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size) {
+    return LFS_CRC(crc, buffer, size)
+}
+#else
 uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size);
+#endif
 
 // Allocate memory, only used if buffers are not provided to littlefs
 // Note, memory must be 64-bit aligned

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -217,7 +217,9 @@ uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size);
 // Allocate memory, only used if buffers are not provided to littlefs
 // Note, memory must be 64-bit aligned
 static inline void *lfs_malloc(size_t size) {
-#ifndef LFS_NO_MALLOC
+#if defined(LFS_MALLOC)
+    return LFS_MALLOC(size);
+#elif !defined(LFS_NO_MALLOC)
     return malloc(size);
 #else
     (void)size;
@@ -227,7 +229,9 @@ static inline void *lfs_malloc(size_t size) {
 
 // Deallocate memory, only used if buffers are not provided to littlefs
 static inline void lfs_free(void *p) {
-#ifndef LFS_NO_MALLOC
+#if defined(LFS_FREE)
+    LFS_FREE(p);
+#elif !defined(LFS_NO_MALLOC)
     free(p);
 #else
     (void)p;


### PR DESCRIPTION
With this you can override littlefs's malloc/crc implementations with some simple defines:

```
-DLFS_MALLOC=my_malloc
-DLFS_FREE=my_free
-DLFS_CRC=my_crc
```

I think these are the main "system-level" utils that users want to override, but am open to feedback.

---

Note on LFS_CRC:

Overriding LFS_CRC with something that's not CRC32 is discouraged. Your filesystem will no longer be compatible with other tools. This is only intended for providing hardware acceleration, etc.

---

These are probably what most users expected when wanting to override malloc/free/crc in littlefs, but they haven't been available, since instead littlefs provides a file-level override of builtin utils behind LFS_CONFIG.

The thinking was that there's just too many builtins that could be overriden, lfs_max/min/alignup/npw2/etc/etc/etc, so allowing users to just override the util file provides the best flexibility without a ton of ifdefs.

But it's become clear this is awkward for users that just want to replace malloc/crc.

Maybe the original goal was too optimistic, maybe there's a better way to structure this file, or maybe the best API is just a bunch of ifdefs, I have no idea. This will hopefully continue to evolve.