### PR TITLE
Increase threshold for superblock expansion from ~50% -> ~88% full

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -2151,9 +2151,11 @@ static int lfs_dir_splittingcompact(lfs_t *lfs, lfs_mdir_t *dir,
             return size;
         }
 
-        // do we have extra space? littlefs can't reclaim this space
-        // by itself, so expand cautiously
-        if ((lfs_size_t)size < lfs->block_count/2) {
+        // littlefs cannot reclaim expanded superblocks, so expand cautiously
+        //
+        // if our filesystem is more than ~88% full, don't expand, this is
+        // somewhat arbitrary
+        if (lfs->block_count - size > lfs->block_count/8) {
             LFS_DEBUG("Expanding superblock at rev %"PRIu32, dir->rev);
             int err = lfs_dir_split(lfs, dir, attrs, attrcount,
                     source, begin, end);


### PR DESCRIPTION
Superblock expansion is an irreversible operation. In an effort to prevent superblock expansion from claiming valuable scratch space (important for small, <~8 block filesystems), littlefs prevents superblock expansion when the disk is "mostly full".

In true computer-scientist fashion, this "mostly full" threshold was set to ~50%.

As pointed out by @gbolgradov and @rojer, >~50% utilization is not uncommon, and it can lead to a situation where superblock expansion does not occur in a relatively healthy filesystem, causing focused wear at the root.

To remedy this, the threshold is now increased to ~88% (7/8) full.

This may change in the future and should probably be eventually user configurable.

See https://github.com/littlefs-project/littlefs/issues/901 for more info.