### PR TITLE
Relaxed lookahead alignment, other internal block alloc readability improvements

### DIFF
--- a/lfs.h
+++ b/lfs.h
@@ -226,7 +226,7 @@ struct lfs_config {
     // Size of the lookahead buffer in bytes. A larger lookahead buffer
     // increases the number of blocks found during an allocation pass. The
     // lookahead buffer is stored as a compact bitmap, so each byte of RAM
-    // can track 8 blocks. Must be a multiple of 8.
+    // can track 8 blocks.
     lfs_size_t lookahead_size;
 
     // Optional statically allocated read buffer. Must be cache_size.
@@ -237,9 +237,8 @@ struct lfs_config {
     // By default lfs_malloc is used to allocate this buffer.
     void *prog_buffer;
 
-    // Optional statically allocated lookahead buffer. Must be lookahead_size
-    // and aligned to a 32-bit boundary. By default lfs_malloc is used to
-    // allocate this buffer.
+    // Optional statically allocated lookahead buffer. Must be lookahead_size.
+    // By default lfs_malloc is used to allocate this buffer.
     void *lookahead_buffer;
 
     // Optional upper limit on length of file names in bytes. No downside for
@@ -435,7 +434,7 @@ typedef struct lfs {
         lfs_block_t size;
         lfs_block_t next;
         lfs_block_t ckpoint;
-        uint32_t *buffer;
+        uint8_t *buffer;
     } lookahead;
 
     const struct lfs_config *cfg;

--- a/lfs.h
+++ b/lfs.h
@@ -430,13 +430,13 @@ typedef struct lfs {
     lfs_gstate_t gdisk;
     lfs_gstate_t gdelta;
 
-    struct lfs_free {
-        lfs_block_t off;
+    struct lfs_lookahead {
+        lfs_block_t start;
         lfs_block_t size;
-        lfs_block_t i;
-        lfs_block_t ack;
+        lfs_block_t next;
+        lfs_block_t ckpoint;
         uint32_t *buffer;
-    } free;
+    } lookahead;
 
     const struct lfs_config *cfg;
     lfs_size_t block_count;

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -215,7 +215,9 @@ static inline uint32_t lfs_tobe32(uint32_t a) {
 uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size);
 
 // Allocate memory, only used if buffers are not provided to littlefs
-// Note, memory must be 64-bit aligned
+//
+// littlefs current has no alignment requirements, as it only allocates
+// byte-level buffers.
 static inline void *lfs_malloc(size_t size) {
 #ifndef LFS_NO_MALLOC
     return malloc(size);

--- a/tests/test_orphans.toml
+++ b/tests/test_orphans.toml
@@ -98,7 +98,7 @@ code = '''
     lfs_mount(&lfs, cfg) => 0;
     // create an orphan
     lfs_mdir_t orphan;
-    lfs_alloc_ack(&lfs);
+    lfs_alloc_ckpoint(&lfs);
     lfs_dir_alloc(&lfs, &orphan) => 0;
     lfs_dir_commit(&lfs, &orphan, NULL, 0) => 0;
 
@@ -170,7 +170,7 @@ code = '''
     lfs_mount(&lfs, cfg) => 0;
     // create an orphan
     lfs_mdir_t orphan;
-    lfs_alloc_ack(&lfs);
+    lfs_alloc_ckpoint(&lfs);
     lfs_dir_alloc(&lfs, &orphan) => 0;
     lfs_dir_commit(&lfs, &orphan, NULL, 0) => 0;
 


### PR DESCRIPTION
This drops the lookahead buffer from operating on 32-bit words to operating on 8-bit bytes, and removes any alignment requirement. This may have some minor performance impact, but it is unlikely to be significant when you consider IO overhead.

The original motivation for 32-bit alignment was an attempt at future-proofing in case we wanted some more complex on-disk data structure. This never happened, and even if it did, it could have been added via additional config options.

This has been a significant pain point for users, as providing word-aligned byte-sized buffers in C can be a bit annoying.

---

This also includes a number of internal block allocator improvements, mostly around naming things and making the logic hopefully easier to understand.