### PR TITLE
Extend lfs_fs_gc to compact metadata, compact_thresh 

### DIFF
--- a/lfs.h
+++ b/lfs.h
@@ -226,7 +226,7 @@ struct lfs_config {
     // Size of the lookahead buffer in bytes. A larger lookahead buffer
     // increases the number of blocks found during an allocation pass. The
     // lookahead buffer is stored as a compact bitmap, so each byte of RAM
-    // can track 8 blocks. Must be a multiple of 8.
+    // can track 8 blocks.
     lfs_size_t lookahead_size;
 
     // Optional statically allocated read buffer. Must be cache_size.
@@ -237,9 +237,8 @@ struct lfs_config {
     // By default lfs_malloc is used to allocate this buffer.
     void *prog_buffer;
 
-    // Optional statically allocated lookahead buffer. Must be lookahead_size
-    // and aligned to a 32-bit boundary. By default lfs_malloc is used to
-    // allocate this buffer.
+    // Optional statically allocated lookahead buffer. Must be lookahead_size.
+    // By default lfs_malloc is used to allocate this buffer.
     void *lookahead_buffer;
 
     // Optional upper limit on length of file names in bytes. No downside for
@@ -435,7 +434,7 @@ typedef struct lfs {
         lfs_block_t size;
         lfs_block_t next;
         lfs_block_t ckpoint;
-        uint32_t *buffer;
+        uint8_t *buffer;
     } lookahead;
 
     const struct lfs_config *cfg;

--- a/lfs.h
+++ b/lfs.h
@@ -430,13 +430,13 @@ typedef struct lfs {
     lfs_gstate_t gdisk;
     lfs_gstate_t gdelta;
 
-    struct lfs_free {
-        lfs_block_t off;
+    struct lfs_lookahead {
+        lfs_block_t start;
         lfs_block_t size;
-        lfs_block_t i;
-        lfs_block_t ack;
+        lfs_block_t next;
+        lfs_block_t ckpoint;
         uint32_t *buffer;
-    } free;
+    } lookahead;
 
     const struct lfs_config *cfg;
     lfs_size_t block_count;

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -215,7 +215,9 @@ static inline uint32_t lfs_tobe32(uint32_t a) {
 uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size);
 
 // Allocate memory, only used if buffers are not provided to littlefs
-// Note, memory must be 64-bit aligned
+//
+// littlefs current has no alignment requirements, as it only allocates
+// byte-level buffers.
 static inline void *lfs_malloc(size_t size) {
 #ifndef LFS_NO_MALLOC
     return malloc(size);

--- a/runners/bench_runner.c
+++ b/runners/bench_runner.c
@@ -1321,6 +1321,7 @@ void perm_run(
         .block_cycles       = BLOCK_CYCLES,
         .cache_size         = CACHE_SIZE,
         .lookahead_size     = LOOKAHEAD_SIZE,
+        .compact_thresh     = COMPACT_THRESH,
     };
 
     struct lfs_emubd_config bdcfg = {

--- a/runners/bench_runner.h
+++ b/runners/bench_runner.h
@@ -95,11 +95,12 @@ intmax_t bench_define(size_t define);
 #define BLOCK_COUNT_i        5
 #define CACHE_SIZE_i         6
 #define LOOKAHEAD_SIZE_i     7
-#define BLOCK_CYCLES_i       8
-#define ERASE_VALUE_i        9
-#define ERASE_CYCLES_i       10
-#define BADBLOCK_BEHAVIOR_i  11
-#define POWERLOSS_BEHAVIOR_i 12
+#define COMPACT_THRESH_i     8
+#define BLOCK_CYCLES_i       9
+#define ERASE_VALUE_i        10
+#define ERASE_CYCLES_i       11
+#define BADBLOCK_BEHAVIOR_i  12
+#define POWERLOSS_BEHAVIOR_i 13
 
 #define READ_SIZE           bench_define(READ_SIZE_i)
 #define PROG_SIZE           bench_define(PROG_SIZE_i)
@@ -109,6 +110,7 @@ intmax_t bench_define(size_t define);
 #define BLOCK_COUNT         bench_define(BLOCK_COUNT_i)
 #define CACHE_SIZE          bench_define(CACHE_SIZE_i)
 #define LOOKAHEAD_SIZE      bench_define(LOOKAHEAD_SIZE_i)
+#define COMPACT_THRESH      bench_define(COMPACT_THRESH_i)
 #define BLOCK_CYCLES        bench_define(BLOCK_CYCLES_i)
 #define ERASE_VALUE         bench_define(ERASE_VALUE_i)
 #define ERASE_CYCLES        bench_define(ERASE_CYCLES_i)
@@ -124,6 +126,7 @@ intmax_t bench_define(size_t define);
     BENCH_DEF(BLOCK_COUNT,        ERASE_COUNT/lfs_max(BLOCK_SIZE/ERASE_SIZE,1))\
     BENCH_DEF(CACHE_SIZE,         lfs_max(64,lfs_max(READ_SIZE,PROG_SIZE))) \
     BENCH_DEF(LOOKAHEAD_SIZE,     16) \
+    BENCH_DEF(COMPACT_THRESH,     0) \
     BENCH_DEF(BLOCK_CYCLES,       -1) \
     BENCH_DEF(ERASE_VALUE,        0xff) \
     BENCH_DEF(ERASE_CYCLES,       0) \
@@ -131,7 +134,7 @@ intmax_t bench_define(size_t define);
     BENCH_DEF(POWERLOSS_BEHAVIOR, LFS_EMUBD_POWERLOSS_NOOP)
 
 #define BENCH_GEOMETRY_DEFINE_COUNT 4
-#define BENCH_IMPLICIT_DEFINE_COUNT 13
+#define BENCH_IMPLICIT_DEFINE_COUNT 14
 
 
 #endif

--- a/runners/test_runner.c
+++ b/runners/test_runner.c
@@ -1346,6 +1346,7 @@ static void run_powerloss_none(
         .block_cycles       = BLOCK_CYCLES,
         .cache_size         = CACHE_SIZE,
         .lookahead_size     = LOOKAHEAD_SIZE,
+        .compact_thresh     = COMPACT_THRESH,
     #ifdef LFS_MULTIVERSION
         .disk_version       = DISK_VERSION,
     #endif
@@ -1422,6 +1423,7 @@ static void run_powerloss_linear(
         .block_cycles       = BLOCK_CYCLES,
         .cache_size         = CACHE_SIZE,
         .lookahead_size     = LOOKAHEAD_SIZE,
+        .compact_thresh     = COMPACT_THRESH,
     #ifdef LFS_MULTIVERSION
         .disk_version       = DISK_VERSION,
     #endif
@@ -1515,6 +1517,7 @@ static void run_powerloss_log(
         .block_cycles       = BLOCK_CYCLES,
         .cache_size         = CACHE_SIZE,
         .lookahead_size     = LOOKAHEAD_SIZE,
+        .compact_thresh     = COMPACT_THRESH,
     #ifdef LFS_MULTIVERSION
         .disk_version       = DISK_VERSION,
     #endif
@@ -1606,6 +1609,7 @@ static void run_powerloss_cycles(
         .block_cycles       = BLOCK_CYCLES,
         .cache_size         = CACHE_SIZE,
         .lookahead_size     = LOOKAHEAD_SIZE,
+        .compact_thresh     = COMPACT_THRESH,
     #ifdef LFS_MULTIVERSION
         .disk_version       = DISK_VERSION,
     #endif
@@ -1795,6 +1799,7 @@ static void run_powerloss_exhaustive(
         .block_cycles       = BLOCK_CYCLES,
         .cache_size         = CACHE_SIZE,
         .lookahead_size     = LOOKAHEAD_SIZE,
+        .compact_thresh     = COMPACT_THRESH,
     #ifdef LFS_MULTIVERSION
         .disk_version       = DISK_VERSION,
     #endif

--- a/runners/test_runner.h
+++ b/runners/test_runner.h
@@ -88,12 +88,13 @@ intmax_t test_define(size_t define);
 #define BLOCK_COUNT_i        5
 #define CACHE_SIZE_i         6
 #define LOOKAHEAD_SIZE_i     7
-#define BLOCK_CYCLES_i       8
-#define ERASE_VALUE_i        9
-#define ERASE_CYCLES_i       10
-#define BADBLOCK_BEHAVIOR_i  11
-#define POWERLOSS_BEHAVIOR_i 12
-#define DISK_VERSION_i       13
+#define COMPACT_THRESH_i     8
+#define BLOCK_CYCLES_i       9
+#define ERASE_VALUE_i        10
+#define ERASE_CYCLES_i       11
+#define BADBLOCK_BEHAVIOR_i  12
+#define POWERLOSS_BEHAVIOR_i 13
+#define DISK_VERSION_i       14
 
 #define READ_SIZE           TEST_DEFINE(READ_SIZE_i)
 #define PROG_SIZE           TEST_DEFINE(PROG_SIZE_i)
@@ -103,6 +104,7 @@ intmax_t test_define(size_t define);
 #define BLOCK_COUNT         TEST_DEFINE(BLOCK_COUNT_i)
 #define CACHE_SIZE          TEST_DEFINE(CACHE_SIZE_i)
 #define LOOKAHEAD_SIZE      TEST_DEFINE(LOOKAHEAD_SIZE_i)
+#define COMPACT_THRESH      TEST_DEFINE(COMPACT_THRESH_i)
 #define BLOCK_CYCLES        TEST_DEFINE(BLOCK_CYCLES_i)
 #define ERASE_VALUE         TEST_DEFINE(ERASE_VALUE_i)
 #define ERASE_CYCLES        TEST_DEFINE(ERASE_CYCLES_i)
@@ -119,6 +121,7 @@ intmax_t test_define(size_t define);
     TEST_DEF(BLOCK_COUNT,        ERASE_COUNT/lfs_max(BLOCK_SIZE/ERASE_SIZE,1)) \
     TEST_DEF(CACHE_SIZE,         lfs_max(64,lfs_max(READ_SIZE,PROG_SIZE))) \
     TEST_DEF(LOOKAHEAD_SIZE,     16) \
+    TEST_DEF(COMPACT_THRESH,     0) \
     TEST_DEF(BLOCK_CYCLES,       -1) \
     TEST_DEF(ERASE_VALUE,        0xff) \
     TEST_DEF(ERASE_CYCLES,       0) \
@@ -127,7 +130,7 @@ intmax_t test_define(size_t define);
     TEST_DEF(DISK_VERSION,       0)
 
 #define TEST_GEOMETRY_DEFINE_COUNT 4
-#define TEST_IMPLICIT_DEFINE_COUNT 14
+#define TEST_IMPLICIT_DEFINE_COUNT 15
 
 
 #endif

--- a/tests/test_alloc.toml
+++ b/tests/test_alloc.toml
@@ -7,6 +7,7 @@ if = 'BLOCK_CYCLES == -1'
 defines.FILES = 3
 defines.SIZE = '(((BLOCK_SIZE-8)*(BLOCK_COUNT-6)) / FILES)'
 defines.GC = [false, true]
+defines.COMPACT_THRESH = ['-1', '0', 'BLOCK_SIZE/2']
 code = '''
     const char *names[] = {"bacon", "eggs", "pancakes"};
     lfs_file_t files[FILES];
@@ -60,6 +61,7 @@ code = '''
 defines.FILES = 3
 defines.SIZE = '(((BLOCK_SIZE-8)*(BLOCK_COUNT-6)) / FILES)'
 defines.GC = [false, true]
+defines.COMPACT_THRESH = ['-1', '0', 'BLOCK_SIZE/2']
 code = '''
     const char *names[] = {"bacon", "eggs", "pancakes"};
 

--- a/tests/test_orphans.toml
+++ b/tests/test_orphans.toml
@@ -98,7 +98,7 @@ code = '''
     lfs_mount(&lfs, cfg) => 0;
     // create an orphan
     lfs_mdir_t orphan;
-    lfs_alloc_ack(&lfs);
+    lfs_alloc_ckpoint(&lfs);
     lfs_dir_alloc(&lfs, &orphan) => 0;
     lfs_dir_commit(&lfs, &orphan, NULL, 0) => 0;
 
@@ -170,7 +170,7 @@ code = '''
     lfs_mount(&lfs, cfg) => 0;
     // create an orphan
     lfs_mdir_t orphan;
-    lfs_alloc_ack(&lfs);
+    lfs_alloc_ckpoint(&lfs);
     lfs_dir_alloc(&lfs, &orphan) => 0;
     lfs_dir_commit(&lfs, &orphan, NULL, 0) => 0;
 


### PR DESCRIPTION
This extends `lfs_fs_gc` to now handle three things:

1. Calls mkconsistent if not already consistent
2. Compacts metadata > `compact_thresh`
3. Populates the block allocator

Which should be all of the janitorial work that can be done without additional on-disk data structures.

Normally, metadata compaction occurs when an mdir is full, and results in mdirs that are at most `block_size/2`.

Now, if you call lfs_fs_gc, littlefs will eagerly compact any mdirs that exceed the `compact_thresh` configuration option. Because the resulting mdirs are at most `block_size/2`, it only makes sense for `compact_thresh` to be >= `block_size/2` and <= `block_size`.

Additionally, there are some special values:

- `compact_thresh=0`  => defaults to ~88% `block_size`, may change in the future
- `compact_thresh=-1` => disables metadata compaction during `lfs_fs_gc`

Note that `compact_thresh` only affects `lfs_fs_gc`. Normal compactions still only occur when full.

This depends on: https://github.com/littlefs-project/littlefs/pull/912