### PR TITLE
Rename internal functions _raw* -> _*_

### DIFF
--- a/bd/lfs_emubd.c
+++ b/bd/lfs_emubd.c
@@ -451,7 +451,7 @@ int lfs_emubd_sync(const struct lfs_config *cfg) {
 
 /// Additional extended API for driving test features ///
 
-static int lfs_emubd_rawcrc(const struct lfs_config *cfg,
+static int lfs_emubd_crc_(const struct lfs_config *cfg,
         lfs_block_t block, uint32_t *crc) {
     lfs_emubd_t *bd = cfg->context;
 
@@ -480,7 +480,7 @@ int lfs_emubd_crc(const struct lfs_config *cfg,
         lfs_block_t block, uint32_t *crc) {
     LFS_EMUBD_TRACE("lfs_emubd_crc(%p, %"PRIu32", %p)",
             (void*)cfg, block, crc);
-    int err = lfs_emubd_rawcrc(cfg, block, crc);
+    int err = lfs_emubd_crc_(cfg, block, crc);
     LFS_EMUBD_TRACE("lfs_emubd_crc -> %d", err);
     return err;
 }
@@ -491,7 +491,7 @@ int lfs_emubd_bdcrc(const struct lfs_config *cfg, uint32_t *crc) {
     uint32_t crc_ = 0xffffffff;
     for (lfs_block_t i = 0; i < cfg->block_count; i++) {
         uint32_t i_crc;
-        int err = lfs_emubd_rawcrc(cfg, i, &i_crc);
+        int err = lfs_emubd_crc_(cfg, i, &i_crc);
         if (err) {
             LFS_EMUBD_TRACE("lfs_emubd_bdcrc -> %d", err);
             return err;

--- a/lfs.c
+++ b/lfs.c
@@ -550,9 +550,9 @@ static int lfs_dir_compact(lfs_t *lfs,
         lfs_mdir_t *source, uint16_t begin, uint16_t end);
 static lfs_ssize_t lfs_file_flushedwrite(lfs_t *lfs, lfs_file_t *file,
         const void *buffer, lfs_size_t size);
-static lfs_ssize_t lfs_file_rawwrite(lfs_t *lfs, lfs_file_t *file,
+static lfs_ssize_t lfs_file_write_(lfs_t *lfs, lfs_file_t *file,
         const void *buffer, lfs_size_t size);
-static int lfs_file_rawsync(lfs_t *lfs, lfs_file_t *file);
+static int lfs_file_sync_(lfs_t *lfs, lfs_file_t *file);
 static int lfs_file_outline(lfs_t *lfs, lfs_file_t *file);
 static int lfs_file_flush(lfs_t *lfs, lfs_file_t *file);
 
@@ -574,22 +574,22 @@ static int lfs1_traverse(lfs_t *lfs,
         int (*cb)(void*, lfs_block_t), void *data);
 #endif
 
-static int lfs_dir_rawrewind(lfs_t *lfs, lfs_dir_t *dir);
+static int lfs_dir_rewind_(lfs_t *lfs, lfs_dir_t *dir);
 
 static lfs_ssize_t lfs_file_flushedread(lfs_t *lfs, lfs_file_t *file,
         void *buffer, lfs_size_t size);
-static lfs_ssize_t lfs_file_rawread(lfs_t *lfs, lfs_file_t *file,
+static lfs_ssize_t lfs_file_read_(lfs_t *lfs, lfs_file_t *file,
         void *buffer, lfs_size_t size);
-static int lfs_file_rawclose(lfs_t *lfs, lfs_file_t *file);
-static lfs_soff_t lfs_file_rawsize(lfs_t *lfs, lfs_file_t *file);
+static int lfs_file_close_(lfs_t *lfs, lfs_file_t *file);
+static lfs_soff_t lfs_file_size_(lfs_t *lfs, lfs_file_t *file);
 
-static lfs_ssize_t lfs_fs_rawsize(lfs_t *lfs);
-static int lfs_fs_rawtraverse(lfs_t *lfs,
+static lfs_ssize_t lfs_fs_size_(lfs_t *lfs);
+static int lfs_fs_traverse_(lfs_t *lfs,
         int (*cb)(void *data, lfs_block_t block), void *data,
         bool includeorphans);
 
 static int lfs_deinit(lfs_t *lfs);
-static int lfs_rawunmount(lfs_t *lfs);
+static int lfs_unmount_(lfs_t *lfs);
 
 
 /// Block allocator ///
@@ -639,7 +639,7 @@ static int lfs_alloc_scan(lfs_t *lfs) {
 
     // find mask of free blocks from tree
     memset(lfs->lookahead.buffer, 0, lfs->cfg->lookahead_size);
-    int err = lfs_fs_rawtraverse(lfs, lfs_alloc_lookahead, lfs, true);
+    int err = lfs_fs_traverse_(lfs, lfs_alloc_lookahead, lfs, true);
     if (err) {
         lfs_alloc_drop(lfs);
         return err;
@@ -2166,7 +2166,7 @@ static int lfs_dir_splittingcompact(lfs_t *lfs, lfs_mdir_t *dir,
             && lfs_pair_cmp(dir->pair, (const lfs_block_t[2]){0, 1}) == 0) {
         // oh no! we're writing too much to the superblock,
         // should we expand?
-        lfs_ssize_t size = lfs_fs_rawsize(lfs);
+        lfs_ssize_t size = lfs_fs_size_(lfs);
         if (size < 0) {
             return size;
         }
@@ -2586,7 +2586,7 @@ static int lfs_dir_commit(lfs_t *lfs, lfs_mdir_t *dir,
 
 /// Top level directory operations ///
 #ifndef LFS_READONLY
-static int lfs_rawmkdir(lfs_t *lfs, const char *path) {
+static int lfs_mkdir_(lfs_t *lfs, const char *path) {
     // deorphan if we haven't yet, needed at most once after poweron
     int err = lfs_fs_forceconsistency(lfs);
     if (err) {
@@ -2682,7 +2682,7 @@ static int lfs_rawmkdir(lfs_t *lfs, const char *path) {
 }
 #endif
 
-static int lfs_dir_rawopen(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
+static int lfs_dir_open_(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
     lfs_stag_t tag = lfs_dir_find(lfs, &dir->m, &path, NULL);
     if (tag < 0) {
         return tag;
@@ -2726,14 +2726,14 @@ static int lfs_dir_rawopen(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
     return 0;
 }
 
-static int lfs_dir_rawclose(lfs_t *lfs, lfs_dir_t *dir) {
+static int lfs_dir_close_(lfs_t *lfs, lfs_dir_t *dir) {
     // remove from list of mdirs
     lfs_mlist_remove(lfs, (struct lfs_mlist *)dir);
 
     return 0;
 }
 
-static int lfs_dir_rawread(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
+static int lfs_dir_read_(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
     memset(info, 0, sizeof(*info));
 
     // special offset for '.' and '..'
@@ -2778,9 +2778,9 @@ static int lfs_dir_rawread(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
     return true;
 }
 
-static int lfs_dir_rawseek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
+static int lfs_dir_seek_(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
     // simply walk from head dir
-    int err = lfs_dir_rawrewind(lfs, dir);
+    int err = lfs_dir_rewind_(lfs, dir);
     if (err) {
         return err;
     }
@@ -2815,12 +2815,12 @@ static int lfs_dir_rawseek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
     return 0;
 }
 
-static lfs_soff_t lfs_dir_rawtell(lfs_t *lfs, lfs_dir_t *dir) {
+static lfs_soff_t lfs_dir_tell_(lfs_t *lfs, lfs_dir_t *dir) {
     (void)lfs;
     return dir->pos;
 }
 
-static int lfs_dir_rawrewind(lfs_t *lfs, lfs_dir_t *dir) {
+static int lfs_dir_rewind_(lfs_t *lfs, lfs_dir_t *dir) {
     // reload the head dir
     int err = lfs_dir_fetch(lfs, &dir->m, dir->head);
     if (err) {
@@ -3026,7 +3026,7 @@ static int lfs_ctz_traverse(lfs_t *lfs,
 
 
 /// Top level file operations ///
-static int lfs_file_rawopencfg(lfs_t *lfs, lfs_file_t *file,
+static int lfs_file_opencfg_(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags,
         const struct lfs_file_config *cfg) {
 #ifndef LFS_READONLY
@@ -3188,22 +3188,22 @@ cleanup:
 #ifndef LFS_READONLY
     file->flags |= LFS_F_ERRED;
 #endif
-    lfs_file_rawclose(lfs, file);
+    lfs_file_close_(lfs, file);
     return err;
 }
 
 #ifndef LFS_NO_MALLOC
-static int lfs_file_rawopen(lfs_t *lfs, lfs_file_t *file,
+static int lfs_file_open_(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags) {
     static const struct lfs_file_config defaults = {0};
-    int err = lfs_file_rawopencfg(lfs, file, path, flags, &defaults);
+    int err = lfs_file_opencfg_(lfs, file, path, flags, &defaults);
     return err;
 }
 #endif
 
-static int lfs_file_rawclose(lfs_t *lfs, lfs_file_t *file) {
+static int lfs_file_close_(lfs_t *lfs, lfs_file_t *file) {
 #ifndef LFS_READONLY
-    int err = lfs_file_rawsync(lfs, file);
+    int err = lfs_file_sync_(lfs, file);
 #else
     int err = 0;
 #endif
@@ -3386,7 +3386,7 @@ relocate:
 }
 
 #ifndef LFS_READONLY
-static int lfs_file_rawsync(lfs_t *lfs, lfs_file_t *file) {
+static int lfs_file_sync_(lfs_t *lfs, lfs_file_t *file) {
     if (file->flags & LFS_F_ERRED) {
         // it's not safe to do anything if our file errored
         return 0;
@@ -3499,7 +3499,7 @@ static lfs_ssize_t lfs_file_flushedread(lfs_t *lfs, lfs_file_t *file,
     return size;
 }
 
-static lfs_ssize_t lfs_file_rawread(lfs_t *lfs, lfs_file_t *file,
+static lfs_ssize_t lfs_file_read_(lfs_t *lfs, lfs_file_t *file,
         void *buffer, lfs_size_t size) {
     LFS_ASSERT((file->flags & LFS_O_RDONLY) == LFS_O_RDONLY);
 
@@ -3602,7 +3602,7 @@ relocate:
     return size;
 }
 
-static lfs_ssize_t lfs_file_rawwrite(lfs_t *lfs, lfs_file_t *file,
+static lfs_ssize_t lfs_file_write_(lfs_t *lfs, lfs_file_t *file,
         const void *buffer, lfs_size_t size) {
     LFS_ASSERT((file->flags & LFS_O_WRONLY) == LFS_O_WRONLY);
 
@@ -3646,7 +3646,7 @@ static lfs_ssize_t lfs_file_rawwrite(lfs_t *lfs, lfs_file_t *file,
 }
 #endif
 
-static lfs_soff_t lfs_file_rawseek(lfs_t *lfs, lfs_file_t *file,
+static lfs_soff_t lfs_file_seek_(lfs_t *lfs, lfs_file_t *file,
         lfs_soff_t off, int whence) {
     // find new pos
     lfs_off_t npos = file->pos;
@@ -3659,7 +3659,7 @@ static lfs_soff_t lfs_file_rawseek(lfs_t *lfs, lfs_file_t *file,
             npos = file->pos + off;
         }
     } else if (whence == LFS_SEEK_END) {
-        lfs_soff_t res = lfs_file_rawsize(lfs, file) + off;
+        lfs_soff_t res = lfs_file_size_(lfs, file) + off;
         if (res < 0) {
             return LFS_ERR_INVAL;
         } else {
@@ -3710,7 +3710,7 @@ static lfs_soff_t lfs_file_rawseek(lfs_t *lfs, lfs_file_t *file,
 }
 
 #ifndef LFS_READONLY
-static int lfs_file_rawtruncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
+static int lfs_file_truncate_(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     LFS_ASSERT((file->flags & LFS_O_WRONLY) == LFS_O_WRONLY);
 
     if (size > LFS_FILE_MAX) {
@@ -3718,12 +3718,12 @@ static int lfs_file_rawtruncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     }
 
     lfs_off_t pos = file->pos;
-    lfs_off_t oldsize = lfs_file_rawsize(lfs, file);
+    lfs_off_t oldsize = lfs_file_size_(lfs, file);
     if (size < oldsize) {
         // revert to inline file?
         if (size <= lfs->inline_max) {
             // flush+seek to head
-            lfs_soff_t res = lfs_file_rawseek(lfs, file, 0, LFS_SEEK_SET);
+            lfs_soff_t res = lfs_file_seek_(lfs, file, 0, LFS_SEEK_SET);
             if (res < 0) {
                 return (int)res;
             }
@@ -3768,14 +3768,14 @@ static int lfs_file_rawtruncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
         }
     } else if (size > oldsize) {
         // flush+seek if not already at end
-        lfs_soff_t res = lfs_file_rawseek(lfs, file, 0, LFS_SEEK_END);
+        lfs_soff_t res = lfs_file_seek_(lfs, file, 0, LFS_SEEK_END);
         if (res < 0) {
             return (int)res;
         }
 
         // fill with zeros
         while (file->pos < size) {
-            res = lfs_file_rawwrite(lfs, file, &(uint8_t){0}, 1);
+            res = lfs_file_write_(lfs, file, &(uint8_t){0}, 1);
             if (res < 0) {
                 return (int)res;
             }
@@ -3783,7 +3783,7 @@ static int lfs_file_rawtruncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     }
 
     // restore pos
-    lfs_soff_t res = lfs_file_rawseek(lfs, file, pos, LFS_SEEK_SET);
+    lfs_soff_t res = lfs_file_seek_(lfs, file, pos, LFS_SEEK_SET);
     if (res < 0) {
       return (int)res;
     }
@@ -3792,13 +3792,13 @@ static int lfs_file_rawtruncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
 }
 #endif
 
-static lfs_soff_t lfs_file_rawtell(lfs_t *lfs, lfs_file_t *file) {
+static lfs_soff_t lfs_file_tell_(lfs_t *lfs, lfs_file_t *file) {
     (void)lfs;
     return file->pos;
 }
 
-static int lfs_file_rawrewind(lfs_t *lfs, lfs_file_t *file) {
-    lfs_soff_t res = lfs_file_rawseek(lfs, file, 0, LFS_SEEK_SET);
+static int lfs_file_rewind_(lfs_t *lfs, lfs_file_t *file) {
+    lfs_soff_t res = lfs_file_seek_(lfs, file, 0, LFS_SEEK_SET);
     if (res < 0) {
         return (int)res;
     }
@@ -3806,7 +3806,7 @@ static int lfs_file_rawrewind(lfs_t *lfs, lfs_file_t *file) {
     return 0;
 }
 
-static lfs_soff_t lfs_file_rawsize(lfs_t *lfs, lfs_file_t *file) {
+static lfs_soff_t lfs_file_size_(lfs_t *lfs, lfs_file_t *file) {
     (void)lfs;
 
 #ifndef LFS_READONLY
@@ -3820,7 +3820,7 @@ static lfs_soff_t lfs_file_rawsize(lfs_t *lfs, lfs_file_t *file) {
 
 
 /// General fs operations ///
-static int lfs_rawstat(lfs_t *lfs, const char *path, struct lfs_info *info) {
+static int lfs_stat_(lfs_t *lfs, const char *path, struct lfs_info *info) {
     lfs_mdir_t cwd;
     lfs_stag_t tag = lfs_dir_find(lfs, &cwd, &path, NULL);
     if (tag < 0) {
@@ -3831,7 +3831,7 @@ static int lfs_rawstat(lfs_t *lfs, const char *path, struct lfs_info *info) {
 }
 
 #ifndef LFS_READONLY
-static int lfs_rawremove(lfs_t *lfs, const char *path) {
+static int lfs_remove_(lfs_t *lfs, const char *path) {
     // deorphan if we haven't yet, needed at most once after poweron
     int err = lfs_fs_forceconsistency(lfs);
     if (err) {
@@ -3910,7 +3910,7 @@ static int lfs_rawremove(lfs_t *lfs, const char *path) {
 #endif
 
 #ifndef LFS_READONLY
-static int lfs_rawrename(lfs_t *lfs, const char *oldpath, const char *newpath) {
+static int lfs_rename_(lfs_t *lfs, const char *oldpath, const char *newpath) {
     // deorphan if we haven't yet, needed at most once after poweron
     int err = lfs_fs_forceconsistency(lfs);
     if (err) {
@@ -4047,7 +4047,7 @@ static int lfs_rawrename(lfs_t *lfs, const char *oldpath, const char *newpath) {
 }
 #endif
 
-static lfs_ssize_t lfs_rawgetattr(lfs_t *lfs, const char *path,
+static lfs_ssize_t lfs_getattr_(lfs_t *lfs, const char *path,
         uint8_t type, void *buffer, lfs_size_t size) {
     lfs_mdir_t cwd;
     lfs_stag_t tag = lfs_dir_find(lfs, &cwd, &path, NULL);
@@ -4105,7 +4105,7 @@ static int lfs_commitattr(lfs_t *lfs, const char *path,
 #endif
 
 #ifndef LFS_READONLY
-static int lfs_rawsetattr(lfs_t *lfs, const char *path,
+static int lfs_setattr_(lfs_t *lfs, const char *path,
         uint8_t type, const void *buffer, lfs_size_t size) {
     if (size > lfs->attr_max) {
         return LFS_ERR_NOSPC;
@@ -4116,7 +4116,7 @@ static int lfs_rawsetattr(lfs_t *lfs, const char *path,
 #endif
 
 #ifndef LFS_READONLY
-static int lfs_rawremoveattr(lfs_t *lfs, const char *path, uint8_t type) {
+static int lfs_removeattr_(lfs_t *lfs, const char *path, uint8_t type) {
     return lfs_commitattr(lfs, path, type, NULL, 0x3ff);
 }
 #endif
@@ -4314,7 +4314,7 @@ static int lfs_deinit(lfs_t *lfs) {
 
 
 #ifndef LFS_READONLY
-static int lfs_rawformat(lfs_t *lfs, const struct lfs_config *cfg) {
+static int lfs_format_(lfs_t *lfs, const struct lfs_config *cfg) {
     int err = 0;
     {
         err = lfs_init(lfs, cfg);
@@ -4381,7 +4381,7 @@ cleanup:
 }
 #endif
 
-static int lfs_rawmount(lfs_t *lfs, const struct lfs_config *cfg) {
+static int lfs_mount_(lfs_t *lfs, const struct lfs_config *cfg) {
     int err = lfs_init(lfs, cfg);
     if (err) {
         return err;
@@ -4547,17 +4547,17 @@ static int lfs_rawmount(lfs_t *lfs, const struct lfs_config *cfg) {
     return 0;
 
 cleanup:
-    lfs_rawunmount(lfs);
+    lfs_unmount_(lfs);
     return err;
 }
 
-static int lfs_rawunmount(lfs_t *lfs) {
+static int lfs_unmount_(lfs_t *lfs) {
     return lfs_deinit(lfs);
 }
 
 
 /// Filesystem filesystem operations ///
-static int lfs_fs_rawstat(lfs_t *lfs, struct lfs_fsinfo *fsinfo) {
+static int lfs_fs_stat_(lfs_t *lfs, struct lfs_fsinfo *fsinfo) {
     // if the superblock is up-to-date, we must be on the most recent
     // minor version of littlefs
     if (!lfs_gstate_needssuperblock(&lfs->gstate)) {
@@ -4597,7 +4597,7 @@ static int lfs_fs_rawstat(lfs_t *lfs, struct lfs_fsinfo *fsinfo) {
     return 0;
 }
 
-int lfs_fs_rawtraverse(lfs_t *lfs,
+int lfs_fs_traverse_(lfs_t *lfs,
         int (*cb)(void *data, lfs_block_t block), void *data,
         bool includeorphans) {
     // iterate over metadata pairs
@@ -5062,7 +5062,7 @@ static int lfs_fs_forceconsistency(lfs_t *lfs) {
 #endif
 
 #ifndef LFS_READONLY
-static int lfs_fs_rawmkconsistent(lfs_t *lfs) {
+static int lfs_fs_mkconsistent_(lfs_t *lfs) {
     // lfs_fs_forceconsistency does most of the work here
     int err = lfs_fs_forceconsistency(lfs);
     if (err) {
@@ -5098,9 +5098,9 @@ static int lfs_fs_size_count(void *p, lfs_block_t block) {
     return 0;
 }
 
-static lfs_ssize_t lfs_fs_rawsize(lfs_t *lfs) {
+static lfs_ssize_t lfs_fs_size_(lfs_t *lfs) {
     lfs_size_t size = 0;
-    int err = lfs_fs_rawtraverse(lfs, lfs_fs_size_count, &size, false);
+    int err = lfs_fs_traverse_(lfs, lfs_fs_size_count, &size, false);
     if (err) {
         return err;
     }
@@ -5110,7 +5110,7 @@ static lfs_ssize_t lfs_fs_rawsize(lfs_t *lfs) {
 
 // explicit garbage collection
 #ifndef LFS_READONLY
-static int lfs_fs_rawgc(lfs_t *lfs) {
+static int lfs_fs_gc_(lfs_t *lfs) {
     // force consistency, even if we're not necessarily going to write,
     // because this function is supposed to take care of janitorial work
     // isn't it?
@@ -5160,7 +5160,7 @@ static int lfs_fs_rawgc(lfs_t *lfs) {
 #endif
 
 #ifndef LFS_READONLY
-static int lfs_fs_rawgrow(lfs_t *lfs, lfs_size_t block_count) {
+static int lfs_fs_grow_(lfs_t *lfs, lfs_size_t block_count) {
     // shrinking is not supported
     LFS_ASSERT(block_count >= lfs->block_count);
 
@@ -5619,7 +5619,7 @@ static int lfs1_unmount(lfs_t *lfs) {
 }
 
 /// v1 migration ///
-static int lfs_rawmigrate(lfs_t *lfs, const struct lfs_config *cfg) {
+static int lfs_migrate_(lfs_t *lfs, const struct lfs_config *cfg) {
     struct lfs1 lfs1;
 
     // Indeterminate filesystem size not allowed for migration.
@@ -5886,7 +5886,7 @@ int lfs_format(lfs_t *lfs, const struct lfs_config *cfg) {
             cfg->read_buffer, cfg->prog_buffer, cfg->lookahead_buffer,
             cfg->name_max, cfg->file_max, cfg->attr_max);
 
-    err = lfs_rawformat(lfs, cfg);
+    err = lfs_format_(lfs, cfg);
 
     LFS_TRACE("lfs_format -> %d", err);
     LFS_UNLOCK(cfg);
@@ -5916,7 +5916,7 @@ int lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
             cfg->read_buffer, cfg->prog_buffer, cfg->lookahead_buffer,
             cfg->name_max, cfg->file_max, cfg->attr_max);
 
-    err = lfs_rawmount(lfs, cfg);
+    err = lfs_mount_(lfs, cfg);
 
     LFS_TRACE("lfs_mount -> %d", err);
     LFS_UNLOCK(cfg);
@@ -5930,7 +5930,7 @@ int lfs_unmount(lfs_t *lfs) {
     }
     LFS_TRACE("lfs_unmount(%p)", (void*)lfs);
 
-    err = lfs_rawunmount(lfs);
+    err = lfs_unmount_(lfs);
 
     LFS_TRACE("lfs_unmount -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -5945,7 +5945,7 @@ int lfs_remove(lfs_t *lfs, const char *path) {
     }
     LFS_TRACE("lfs_remove(%p, \"%s\")", (void*)lfs, path);
 
-    err = lfs_rawremove(lfs, path);
+    err = lfs_remove_(lfs, path);
 
     LFS_TRACE("lfs_remove -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -5961,7 +5961,7 @@ int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
     }
     LFS_TRACE("lfs_rename(%p, \"%s\", \"%s\")", (void*)lfs, oldpath, newpath);
 
-    err = lfs_rawrename(lfs, oldpath, newpath);
+    err = lfs_rename_(lfs, oldpath, newpath);
 
     LFS_TRACE("lfs_rename -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -5976,7 +5976,7 @@ int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info) {
     }
     LFS_TRACE("lfs_stat(%p, \"%s\", %p)", (void*)lfs, path, (void*)info);
 
-    err = lfs_rawstat(lfs, path, info);
+    err = lfs_stat_(lfs, path, info);
 
     LFS_TRACE("lfs_stat -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -5992,7 +5992,7 @@ lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path,
     LFS_TRACE("lfs_getattr(%p, \"%s\", %"PRIu8", %p, %"PRIu32")",
             (void*)lfs, path, type, buffer, size);
 
-    lfs_ssize_t res = lfs_rawgetattr(lfs, path, type, buffer, size);
+    lfs_ssize_t res = lfs_getattr_(lfs, path, type, buffer, size);
 
     LFS_TRACE("lfs_getattr -> %"PRId32, res);
     LFS_UNLOCK(lfs->cfg);
@@ -6009,7 +6009,7 @@ int lfs_setattr(lfs_t *lfs, const char *path,
     LFS_TRACE("lfs_setattr(%p, \"%s\", %"PRIu8", %p, %"PRIu32")",
             (void*)lfs, path, type, buffer, size);
 
-    err = lfs_rawsetattr(lfs, path, type, buffer, size);
+    err = lfs_setattr_(lfs, path, type, buffer, size);
 
     LFS_TRACE("lfs_setattr -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6025,7 +6025,7 @@ int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type) {
     }
     LFS_TRACE("lfs_removeattr(%p, \"%s\", %"PRIu8")", (void*)lfs, path, type);
 
-    err = lfs_rawremoveattr(lfs, path, type);
+    err = lfs_removeattr_(lfs, path, type);
 
     LFS_TRACE("lfs_removeattr -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6043,7 +6043,7 @@ int lfs_file_open(lfs_t *lfs, lfs_file_t *file, const char *path, int flags) {
             (void*)lfs, (void*)file, path, flags);
     LFS_ASSERT(!lfs_mlist_isopen(lfs->mlist, (struct lfs_mlist*)file));
 
-    err = lfs_file_rawopen(lfs, file, path, flags);
+    err = lfs_file_open_(lfs, file, path, flags);
 
     LFS_TRACE("lfs_file_open -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6064,7 +6064,7 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
             (void*)cfg, cfg->buffer, (void*)cfg->attrs, cfg->attr_count);
     LFS_ASSERT(!lfs_mlist_isopen(lfs->mlist, (struct lfs_mlist*)file));
 
-    err = lfs_file_rawopencfg(lfs, file, path, flags, cfg);
+    err = lfs_file_opencfg_(lfs, file, path, flags, cfg);
 
     LFS_TRACE("lfs_file_opencfg -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6079,7 +6079,7 @@ int lfs_file_close(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_close(%p, %p)", (void*)lfs, (void*)file);
     LFS_ASSERT(lfs_mlist_isopen(lfs->mlist, (struct lfs_mlist*)file));
 
-    err = lfs_file_rawclose(lfs, file);
+    err = lfs_file_close_(lfs, file);
 
     LFS_TRACE("lfs_file_close -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6095,7 +6095,7 @@ int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_sync(%p, %p)", (void*)lfs, (void*)file);
     LFS_ASSERT(lfs_mlist_isopen(lfs->mlist, (struct lfs_mlist*)file));
 
-    err = lfs_file_rawsync(lfs, file);
+    err = lfs_file_sync_(lfs, file);
 
     LFS_TRACE("lfs_file_sync -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6113,7 +6113,7 @@ lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
             (void*)lfs, (void*)file, buffer, size);
     LFS_ASSERT(lfs_mlist_isopen(lfs->mlist, (struct lfs_mlist*)file));
 
-    lfs_ssize_t res = lfs_file_rawread(lfs, file, buffer, size);
+    lfs_ssize_t res = lfs_file_read_(lfs, file, buffer, size);
 
     LFS_TRACE("lfs_file_read -> %"PRId32, res);
     LFS_UNLOCK(lfs->cfg);
@@ -6131,7 +6131,7 @@ lfs_ssize_t lfs_file_write(lfs_t *lfs, lfs_file_t *file,
             (void*)lfs, (void*)file, buffer, size);
     LFS_ASSERT(lfs_mlist_isopen(lfs->mlist, (struct lfs_mlist*)file));
 
-    lfs_ssize_t res = lfs_file_rawwrite(lfs, file, buffer, size);
+    lfs_ssize_t res = lfs_file_write_(lfs, file, buffer, size);
 
     LFS_TRACE("lfs_file_write -> %"PRId32, res);
     LFS_UNLOCK(lfs->cfg);
@@ -6149,7 +6149,7 @@ lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
             (void*)lfs, (void*)file, off, whence);
     LFS_ASSERT(lfs_mlist_isopen(lfs->mlist, (struct lfs_mlist*)file));
 
-    lfs_soff_t res = lfs_file_rawseek(lfs, file, off, whence);
+    lfs_soff_t res = lfs_file_seek_(lfs, file, off, whence);
 
     LFS_TRACE("lfs_file_seek -> %"PRId32, res);
     LFS_UNLOCK(lfs->cfg);
@@ -6166,7 +6166,7 @@ int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
             (void*)lfs, (void*)file, size);
     LFS_ASSERT(lfs_mlist_isopen(lfs->mlist, (struct lfs_mlist*)file));
 
-    err = lfs_file_rawtruncate(lfs, file, size);
+    err = lfs_file_truncate_(lfs, file, size);
 
     LFS_TRACE("lfs_file_truncate -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6182,7 +6182,7 @@ lfs_soff_t lfs_file_tell(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_tell(%p, %p)", (void*)lfs, (void*)file);
     LFS_ASSERT(lfs_mlist_isopen(lfs->mlist, (struct lfs_mlist*)file));
 
-    lfs_soff_t res = lfs_file_rawtell(lfs, file);
+    lfs_soff_t res = lfs_file_tell_(lfs, file);
 
     LFS_TRACE("lfs_file_tell -> %"PRId32, res);
     LFS_UNLOCK(lfs->cfg);
@@ -6196,7 +6196,7 @@ int lfs_file_rewind(lfs_t *lfs, lfs_file_t *file) {
     }
     LFS_TRACE("lfs_file_rewind(%p, %p)", (void*)lfs, (void*)file);
 
-    err = lfs_file_rawrewind(lfs, file);
+    err = lfs_file_rewind_(lfs, file);
 
     LFS_TRACE("lfs_file_rewind -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6211,7 +6211,7 @@ lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_size(%p, %p)", (void*)lfs, (void*)file);
     LFS_ASSERT(lfs_mlist_isopen(lfs->mlist, (struct lfs_mlist*)file));
 
-    lfs_soff_t res = lfs_file_rawsize(lfs, file);
+    lfs_soff_t res = lfs_file_size_(lfs, file);
 
     LFS_TRACE("lfs_file_size -> %"PRId32, res);
     LFS_UNLOCK(lfs->cfg);
@@ -6226,7 +6226,7 @@ int lfs_mkdir(lfs_t *lfs, const char *path) {
     }
     LFS_TRACE("lfs_mkdir(%p, \"%s\")", (void*)lfs, path);
 
-    err = lfs_rawmkdir(lfs, path);
+    err = lfs_mkdir_(lfs, path);
 
     LFS_TRACE("lfs_mkdir -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6242,7 +6242,7 @@ int lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
     LFS_TRACE("lfs_dir_open(%p, %p, \"%s\")", (void*)lfs, (void*)dir, path);
     LFS_ASSERT(!lfs_mlist_isopen(lfs->mlist, (struct lfs_mlist*)dir));
 
-    err = lfs_dir_rawopen(lfs, dir, path);
+    err = lfs_dir_open_(lfs, dir, path);
 
     LFS_TRACE("lfs_dir_open -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6256,7 +6256,7 @@ int lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir) {
     }
     LFS_TRACE("lfs_dir_close(%p, %p)", (void*)lfs, (void*)dir);
 
-    err = lfs_dir_rawclose(lfs, dir);
+    err = lfs_dir_close_(lfs, dir);
 
     LFS_TRACE("lfs_dir_close -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6271,7 +6271,7 @@ int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
     LFS_TRACE("lfs_dir_read(%p, %p, %p)",
             (void*)lfs, (void*)dir, (void*)info);
 
-    err = lfs_dir_rawread(lfs, dir, info);
+    err = lfs_dir_read_(lfs, dir, info);
 
     LFS_TRACE("lfs_dir_read -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6286,7 +6286,7 @@ int lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
     LFS_TRACE("lfs_dir_seek(%p, %p, %"PRIu32")",
             (void*)lfs, (void*)dir, off);
 
-    err = lfs_dir_rawseek(lfs, dir, off);
+    err = lfs_dir_seek_(lfs, dir, off);
 
     LFS_TRACE("lfs_dir_seek -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6300,7 +6300,7 @@ lfs_soff_t lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir) {
     }
     LFS_TRACE("lfs_dir_tell(%p, %p)", (void*)lfs, (void*)dir);
 
-    lfs_soff_t res = lfs_dir_rawtell(lfs, dir);
+    lfs_soff_t res = lfs_dir_tell_(lfs, dir);
 
     LFS_TRACE("lfs_dir_tell -> %"PRId32, res);
     LFS_UNLOCK(lfs->cfg);
@@ -6314,7 +6314,7 @@ int lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir) {
     }
     LFS_TRACE("lfs_dir_rewind(%p, %p)", (void*)lfs, (void*)dir);
 
-    err = lfs_dir_rawrewind(lfs, dir);
+    err = lfs_dir_rewind_(lfs, dir);
 
     LFS_TRACE("lfs_dir_rewind -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6328,7 +6328,7 @@ int lfs_fs_stat(lfs_t *lfs, struct lfs_fsinfo *fsinfo) {
     }
     LFS_TRACE("lfs_fs_stat(%p, %p)", (void*)lfs, (void*)fsinfo);
 
-    err = lfs_fs_rawstat(lfs, fsinfo);
+    err = lfs_fs_stat_(lfs, fsinfo);
 
     LFS_TRACE("lfs_fs_stat -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6342,7 +6342,7 @@ lfs_ssize_t lfs_fs_size(lfs_t *lfs) {
     }
     LFS_TRACE("lfs_fs_size(%p)", (void*)lfs);
 
-    lfs_ssize_t res = lfs_fs_rawsize(lfs);
+    lfs_ssize_t res = lfs_fs_size_(lfs);
 
     LFS_TRACE("lfs_fs_size -> %"PRId32, res);
     LFS_UNLOCK(lfs->cfg);
@@ -6357,7 +6357,7 @@ int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void *, lfs_block_t), void *data) {
     LFS_TRACE("lfs_fs_traverse(%p, %p, %p)",
             (void*)lfs, (void*)(uintptr_t)cb, data);
 
-    err = lfs_fs_rawtraverse(lfs, cb, data, true);
+    err = lfs_fs_traverse_(lfs, cb, data, true);
 
     LFS_TRACE("lfs_fs_traverse -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6372,7 +6372,7 @@ int lfs_fs_mkconsistent(lfs_t *lfs) {
     }
     LFS_TRACE("lfs_fs_mkconsistent(%p)", (void*)lfs);
 
-    err = lfs_fs_rawmkconsistent(lfs);
+    err = lfs_fs_mkconsistent_(lfs);
 
     LFS_TRACE("lfs_fs_mkconsistent -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6388,7 +6388,7 @@ int lfs_fs_gc(lfs_t *lfs) {
     }
     LFS_TRACE("lfs_fs_gc(%p)", (void*)lfs);
 
-    err = lfs_fs_rawgc(lfs);
+    err = lfs_fs_gc_(lfs);
 
     LFS_TRACE("lfs_fs_gc -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6404,7 +6404,7 @@ int lfs_fs_grow(lfs_t *lfs, lfs_size_t block_count) {
     }
     LFS_TRACE("lfs_fs_grow(%p, %"PRIu32")", (void*)lfs, block_count);
 
-    err = lfs_fs_rawgrow(lfs, block_count);
+    err = lfs_fs_grow_(lfs, block_count);
 
     LFS_TRACE("lfs_fs_grow -> %d", err);
     LFS_UNLOCK(lfs->cfg);
@@ -6435,7 +6435,7 @@ int lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg) {
             cfg->read_buffer, cfg->prog_buffer, cfg->lookahead_buffer,
             cfg->name_max, cfg->file_max, cfg->attr_max);
 
-    err = lfs_rawmigrate(lfs, cfg);
+    err = lfs_migrate_(lfs, cfg);
 
     LFS_TRACE("lfs_migrate -> %d", err);
     LFS_UNLOCK(cfg);


### PR DESCRIPTION
So instead of `lfs_file_rawopencfg`, it's now `lfs_file_opencfg_`.

The "raw" prefix is annoying, doesn't really add meaning ("internal" would have been better), and gets in the way of finding the relevant function implementations.

I have been using `_`s as suffixes for unimportant name collisions in other codebases, and it seems to work well at reducing wasted brain cycles naming things. Adopting it here avoids the need for "raw" prefixes.

It's quite a bit like the use of prime symbols to resolve name collisions in math, e.g. $x' = x + 1$. Which is even supported in Haskell and is quite nice there.

And the main benefit: Now if you search for the public API name, you get the internal function first, which is probably what you care about.

Here is the exact script:

``` bash
sed -i 's/_raw\([a-z0-9_]*\)\>/_\1_/g' $(git ls-tree -r HEAD --name-only | grep '.*\.c')
```

This should only affect internal symbols, and have no impact on API compatibility.

This PR will rerun and brought in **last** on the next minor release, to minimize impact to other PRs.