### PR TITLE
Change CI to just run on ubuntu-latest

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   post-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       # trigger post-release in dependency repo, this indirection allows the
       # dependency repo to be updated often without affecting this repo. At

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     # need to manually check for a couple things
     # - tests passed?

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -11,7 +11,7 @@ defaults:
 jobs:
   # forward custom statuses
   status:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: dawidd6/action-download-artifact@v2
         continue-on-error: true
@@ -60,7 +60,7 @@ jobs:
 
   # forward custom pr-comments
   comment:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     # only run on success (we don't want garbage comments!)
     if: ${{github.event.workflow_run.conclusion == 'success'}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   # run tests
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -329,7 +329,7 @@ jobs:
   #
   # this grows exponentially, so it doesn't turn out to be that many
   test-pls:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -359,7 +359,7 @@ jobs:
 
   # run with LFS_NO_INTRINSICS to make sure that works
   test-no-intrinsics:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: install
@@ -376,7 +376,7 @@ jobs:
 
   # run LFS_MULTIVERSION tests
   test-multiversion:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: install
@@ -393,7 +393,7 @@ jobs:
 
   # run tests on the older version lfs2.0
   test-lfs2_0:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: install
@@ -412,7 +412,7 @@ jobs:
 
   # run under Valgrind to check for memory errors
   test-valgrind:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: install
@@ -434,7 +434,7 @@ jobs:
   # test that compilation is warning free under clang
   # run with Clang, mostly to check for Clang-specific warnings
   test-clang:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: install
@@ -457,7 +457,7 @@ jobs:
   #
   # note there's no real benefit to running these on multiple archs
   bench:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: install
@@ -533,7 +533,7 @@ jobs:
 
   # run compatibility tests using the current master as the previous version
   test-compat:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         if: ${{github.event_name == 'pull_request'}}
@@ -569,7 +569,7 @@ jobs:
 
   # self-host with littlefs-fuse for a fuzz-like test
   fuse:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: ${{!endsWith(github.ref, '-prefix')}}
     steps:
       - uses: actions/checkout@v2
@@ -619,7 +619,7 @@ jobs:
 
   # test migration using littlefs-fuse
   migrate:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: ${{!endsWith(github.ref, '-prefix')}}
     steps:
       - uses: actions/checkout@v2
@@ -691,7 +691,7 @@ jobs:
 
   # status related tasks that run after tests
   status:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [test, bench]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I ran into this issue on a different repo, GitHub phases out Ubuntu runners after some time, which results in CI just "waiting for runners" indefinitely.

If we already have to bump this version as GitHub phases out older Ubuntu runners (which is reasonable), I don't really see the value of pinning a specific version. We might as well just respond to any broken dependencies caused by GitHub's implicit updates as they happen...

It's not like CI is truly continuous.