### PR TITLE
Fix sync issue where data writes could appear before metadata writes

### DIFF
--- a/bd/lfs_emubd.c
+++ b/bd/lfs_emubd.c
@@ -531,6 +531,7 @@ int lfs_emubd_sync(const struct lfs_config *cfg) {
     // emulate out-of-order writes? reset first write, writes
     // cannot be out-of-order across sync
     if (bd->cfg->powerloss_behavior == LFS_EMUBD_POWERLOSS_OOO) {
+        lfs_emubd_decblock(bd->ooo_data);
         bd->ooo_block = -1;
         bd->ooo_data = NULL;
     }

--- a/bd/lfs_emubd.c
+++ b/bd/lfs_emubd.c
@@ -129,6 +129,8 @@ int lfs_emubd_create(const struct lfs_config *cfg,
     bd->proged = 0;
     bd->erased = 0;
     bd->power_cycles = bd->cfg->power_cycles;
+    bd->ooo_block = -1;
+    bd->ooo_data = NULL;
     bd->disk = NULL;
 
     if (bd->cfg->disk_path) {
@@ -195,6 +197,7 @@ int lfs_emubd_destroy(const struct lfs_config *cfg) {
     free(bd->blocks);
 
     // clean up other resources 
+    lfs_emubd_decblock(bd->ooo_data);
     if (bd->disk) {
         bd->disk->rc -= 1;
         if (bd->disk->rc == 0) {
@@ -208,6 +211,47 @@ int lfs_emubd_destroy(const struct lfs_config *cfg) {
     return 0;
 }
 
+
+// powerloss hook
+static int lfs_emubd_powerloss(const struct lfs_config *cfg) {
+    lfs_emubd_t *bd = cfg->context;
+
+    // emulate out-of-order writes?
+    if (bd->cfg->powerloss_behavior == LFS_EMUBD_POWERLOSS_OOO
+            && bd->ooo_block != -1) {
+        // since writes between syncs are allowed to be out-of-order, it
+        // shouldn't hurt to restore the first write on powerloss, right?
+        lfs_emubd_decblock(bd->blocks[bd->ooo_block]);
+        bd->blocks[bd->ooo_block] = bd->ooo_data;
+
+        // mirror to disk file?
+        if (bd->disk && (bd->ooo_data || bd->cfg->erase_value != -1)) {
+            off_t res1 = lseek(bd->disk->fd,
+                    (off_t)bd->ooo_block*bd->cfg->erase_size,
+                    SEEK_SET);
+            if (res1 < 0) {
+                return -errno;
+            }
+
+            ssize_t res2 = write(bd->disk->fd,
+                    (bd->ooo_data)
+                        ? bd->ooo_data->data
+                        : bd->disk->scratch,
+                    bd->cfg->erase_size);
+            if (res2 < 0) {
+                return -errno;
+            }
+        }
+
+        bd->ooo_block = -1;
+        bd->ooo_data = NULL;
+    }
+
+    // simulate power loss
+    bd->cfg->powerloss_cb(bd->cfg->powerloss_data);
+
+    return 0;
+}
 
 
 // block device API
@@ -344,8 +388,11 @@ int lfs_emubd_prog(const struct lfs_config *cfg, lfs_block_t block,
     if (bd->power_cycles > 0) {
         bd->power_cycles -= 1;
         if (bd->power_cycles == 0) {
-            // simulate power loss
-            bd->cfg->powerloss_cb(bd->cfg->powerloss_data);
+            int err = lfs_emubd_powerloss(cfg);
+            if (err) {
+                LFS_EMUBD_TRACE("lfs_emubd_prog -> %d", err);
+                return err;
+            }
         }
     }
 
@@ -361,10 +408,17 @@ int lfs_emubd_erase(const struct lfs_config *cfg, lfs_block_t block) {
     // check if erase is valid
     LFS_ASSERT(block < bd->cfg->erase_count);
 
+    // emulate out-of-order writes? save first write
+    if (bd->cfg->powerloss_behavior == LFS_EMUBD_POWERLOSS_OOO
+            && bd->ooo_block == -1) {
+        bd->ooo_block = block;
+        bd->ooo_data = lfs_emubd_incblock(bd->blocks[block]);
+    }
+
     // get the block
     lfs_emubd_block_t *b = lfs_emubd_mutblock(cfg, &bd->blocks[block]);
     if (!b) {
-        LFS_EMUBD_TRACE("lfs_emubd_prog -> %d", LFS_ERR_NOMEM);
+        LFS_EMUBD_TRACE("lfs_emubd_erase -> %d", LFS_ERR_NOMEM);
         return LFS_ERR_NOMEM;
     }
 
@@ -430,8 +484,11 @@ int lfs_emubd_erase(const struct lfs_config *cfg, lfs_block_t block) {
     if (bd->power_cycles > 0) {
         bd->power_cycles -= 1;
         if (bd->power_cycles == 0) {
-            // simulate power loss
-            bd->cfg->powerloss_cb(bd->cfg->powerloss_data);
+            int err = lfs_emubd_powerloss(cfg);
+            if (err) {
+                LFS_EMUBD_TRACE("lfs_emubd_erase -> %d", err);
+                return err;
+            }
         }
     }
 
@@ -441,13 +498,19 @@ int lfs_emubd_erase(const struct lfs_config *cfg, lfs_block_t block) {
 
 int lfs_emubd_sync(const struct lfs_config *cfg) {
     LFS_EMUBD_TRACE("lfs_emubd_sync(%p)", (void*)cfg);
+    lfs_emubd_t *bd = cfg->context;
 
-    // do nothing
-    (void)cfg;
+    // emulate out-of-order writes? reset first write, writes
+    // cannot be out-of-order across sync
+    if (bd->cfg->powerloss_behavior == LFS_EMUBD_POWERLOSS_OOO) {
+        bd->ooo_block = -1;
+        bd->ooo_data = NULL;
+    }
 
     LFS_EMUBD_TRACE("lfs_emubd_sync -> %d", 0);
     return 0;
 }
+
 
 /// Additional extended API for driving test features ///
 
@@ -633,6 +696,8 @@ int lfs_emubd_copy(const struct lfs_config *cfg, lfs_emubd_t *copy) {
     copy->proged = bd->proged;
     copy->erased = bd->erased;
     copy->power_cycles = bd->power_cycles;
+    copy->ooo_block = bd->ooo_block;
+    copy->ooo_data = lfs_emubd_incblock(bd->ooo_data);
     copy->disk = bd->disk;
     if (copy->disk) {
         copy->disk->rc += 1;

--- a/bd/lfs_emubd.h
+++ b/bd/lfs_emubd.h
@@ -36,17 +36,18 @@ extern "C"
 // Not that read-noop is not allowed. Read _must_ return a consistent (but
 // may be arbitrary) value on every read.
 typedef enum lfs_emubd_badblock_behavior {
-    LFS_EMUBD_BADBLOCK_PROGERROR,
-    LFS_EMUBD_BADBLOCK_ERASEERROR,
-    LFS_EMUBD_BADBLOCK_READERROR,
-    LFS_EMUBD_BADBLOCK_PROGNOOP,
-    LFS_EMUBD_BADBLOCK_ERASENOOP,
+    LFS_EMUBD_BADBLOCK_PROGERROR  = 0, // Error on prog
+    LFS_EMUBD_BADBLOCK_ERASEERROR = 1, // Error on erase
+    LFS_EMUBD_BADBLOCK_READERROR  = 2, // Error on read
+    LFS_EMUBD_BADBLOCK_PROGNOOP   = 3, // Prog does nothing silently
+    LFS_EMUBD_BADBLOCK_ERASENOOP  = 4, // Erase does nothing silently
 } lfs_emubd_badblock_behavior_t;
 
 // Mode determining how power-loss behaves during testing. For now this
 // only supports a noop behavior, leaving the data on-disk untouched.
 typedef enum lfs_emubd_powerloss_behavior {
-    LFS_EMUBD_POWERLOSS_NOOP,
+    LFS_EMUBD_POWERLOSS_NOOP = 0, // Progs are atomic
+    LFS_EMUBD_POWERLOSS_OOO  = 1, // Blocks are written out-of-order
 } lfs_emubd_powerloss_behavior_t;
 
 // Type for measuring read/program/erase operations
@@ -152,6 +153,8 @@ typedef struct lfs_emubd {
     lfs_emubd_io_t proged;
     lfs_emubd_io_t erased;
     lfs_emubd_powercycles_t power_cycles;
+    lfs_ssize_t ooo_block;
+    lfs_emubd_block_t *ooo_data;
     lfs_emubd_disk_t *disk;
 
     const struct lfs_emubd_config *cfg;

--- a/lfs.c
+++ b/lfs.c
@@ -3401,6 +3401,15 @@ static int lfs_file_sync_(lfs_t *lfs, lfs_file_t *file) {
 
     if ((file->flags & LFS_F_DIRTY) &&
             !lfs_pair_isnull(file->m.pair)) {
+        // before we commit metadata, we need sync the disk to make sure
+        // data writes don't complete after metadata writes
+        if (!(file->flags & LFS_F_INLINE)) {
+            err = lfs_bd_sync(lfs, &lfs->pcache, &lfs->rcache, false);
+            if (err) {
+                return err;
+            }
+        }
+
         // update dir entry
         uint16_t type;
         const void *buffer;

--- a/tests/test_dirs.toml
+++ b/tests/test_dirs.toml
@@ -181,6 +181,10 @@ code = '''
 defines.N = [5, 11]
 if = 'BLOCK_COUNT >= 4*N'
 reentrant = true
+defines.POWERLOSS_BEHAVIOR = [
+    'LFS_EMUBD_POWERLOSS_NOOP',
+    'LFS_EMUBD_POWERLOSS_OOO',
+]
 code = '''
     lfs_t lfs;
     int err = lfs_mount(&lfs, cfg);
@@ -439,6 +443,10 @@ code = '''
 defines.N = [5, 25]
 if = 'N < BLOCK_COUNT/2'
 reentrant = true
+defines.POWERLOSS_BEHAVIOR = [
+    'LFS_EMUBD_POWERLOSS_NOOP',
+    'LFS_EMUBD_POWERLOSS_OOO',
+]
 code = '''
     lfs_t lfs;
     int err = lfs_mount(&lfs, cfg);

--- a/tests/test_files.toml
+++ b/tests/test_files.toml
@@ -310,6 +310,10 @@ defines.SIZE = [32, 0, 7, 2049]
 defines.CHUNKSIZE = [31, 16, 65]
 defines.INLINE_MAX = [0, -1, 8]
 reentrant = true
+defines.POWERLOSS_BEHAVIOR = [
+    'LFS_EMUBD_POWERLOSS_NOOP',
+    'LFS_EMUBD_POWERLOSS_OOO',
+]
 code = '''
     lfs_t lfs;
     int err = lfs_mount(&lfs, cfg);
@@ -500,6 +504,10 @@ code = '''
 [cases.test_files_many_power_loss]
 defines.N = 300
 reentrant = true
+defines.POWERLOSS_BEHAVIOR = [
+    'LFS_EMUBD_POWERLOSS_NOOP',
+    'LFS_EMUBD_POWERLOSS_OOO',
+]
 code = '''
     lfs_t lfs;
     int err = lfs_mount(&lfs, cfg);

--- a/tests/test_interspersed.toml
+++ b/tests/test_interspersed.toml
@@ -195,6 +195,10 @@ code = '''
 defines.SIZE = [10, 100]
 defines.FILES = [4, 10, 26] 
 reentrant = true
+defines.POWERLOSS_BEHAVIOR = [
+    'LFS_EMUBD_POWERLOSS_NOOP',
+    'LFS_EMUBD_POWERLOSS_OOO',
+]
 code = '''
     lfs_t lfs;
     lfs_file_t files[FILES];

--- a/tests/test_move.toml
+++ b/tests/test_move.toml
@@ -357,6 +357,10 @@ code = '''
 
 [cases.test_move_reentrant_file]
 reentrant = true
+defines.POWERLOSS_BEHAVIOR = [
+    'LFS_EMUBD_POWERLOSS_NOOP',
+    'LFS_EMUBD_POWERLOSS_OOO',
+]
 code = '''
     lfs_t lfs;
     int err = lfs_mount(&lfs, cfg);
@@ -839,6 +843,10 @@ code = '''
 
 [cases.test_reentrant_dir]
 reentrant = true
+defines.POWERLOSS_BEHAVIOR = [
+    'LFS_EMUBD_POWERLOSS_NOOP',
+    'LFS_EMUBD_POWERLOSS_OOO',
+]
 code = '''
     lfs_t lfs;
     int err = lfs_mount(&lfs, cfg);

--- a/tests/test_seek.toml
+++ b/tests/test_seek.toml
@@ -329,6 +329,10 @@ code = '''
 # must be power-of-2 for quadratic probing to be exhaustive
 defines.COUNT = [4, 64, 128]
 reentrant = true
+defines.POWERLOSS_BEHAVIOR = [
+    'LFS_EMUBD_POWERLOSS_NOOP',
+    'LFS_EMUBD_POWERLOSS_OOO',
+]
 code = '''
     lfs_t lfs;
     int err = lfs_mount(&lfs, cfg);

--- a/tests/test_superblocks.toml
+++ b/tests/test_superblocks.toml
@@ -32,6 +32,10 @@ code = '''
 # reentrant format
 [cases.test_superblocks_reentrant_format]
 reentrant = true
+defines.POWERLOSS_BEHAVIOR = [
+    'LFS_EMUBD_POWERLOSS_NOOP',
+    'LFS_EMUBD_POWERLOSS_OOO',
+]
 code = '''
     lfs_t lfs;
     int err = lfs_mount(&lfs, cfg);
@@ -174,6 +178,10 @@ code = '''
 defines.BLOCK_CYCLES = [2, 1]
 defines.N = 24
 reentrant = true
+defines.POWERLOSS_BEHAVIOR = [
+    'LFS_EMUBD_POWERLOSS_NOOP',
+    'LFS_EMUBD_POWERLOSS_OOO',
+]
 code = '''
     lfs_t lfs;
     int err = lfs_mount(&lfs, cfg);

--- a/tests/test_truncate.toml
+++ b/tests/test_truncate.toml
@@ -231,6 +231,10 @@ defines.SMALLSIZE = [4, 512]
 defines.MEDIUMSIZE = [0, 3, 4, 5, 31, 32, 33, 511, 512, 513, 1023, 1024, 1025]
 defines.LARGESIZE = 2048
 reentrant = true
+defines.POWERLOSS_BEHAVIOR = [
+    'LFS_EMUBD_POWERLOSS_NOOP',
+    'LFS_EMUBD_POWERLOSS_OOO',
+]
 code = '''
     lfs_t lfs;
     int err = lfs_mount(&lfs, cfg);


### PR DESCRIPTION
Long story short we aren't calling sync correctly in littlefs. This fixes that.

Some forms of storage, mainly anything with an FTL, eMMC, SD, etc, do not guarantee a strict write order for writes to different blocks. In theory this is what bd sync is for, to tell the bd when it is important for the writes to be ordered.

Currently, littlefs calls bd `sync` after committing metadata. This is useful as it ensures that user code can rely on `lfs_file_sync` for ordering external side-effects.

But this is insufficient for handling storage with out-of-order writes.

Consider the simple case of a file with one data block:

1. `lfs_file_write(blablabla)` => writes data into a new data block

2. `lfs_file_sync()` => commits metadata to point to the new data block

But with out-of-order writes, the bd is free to reorder things such that the metadata is updated _before_ the data is written. If we lose power, that would be bad.

The solution to this is to call bd `sync` twice: Once before we commit the metadata to tell the bd that these writes must be ordered, and once after we commit the metadata to allow ordering with user code.

As a small optimization, we only call bd `sync` if the current file is not inlined and has actually been modified (LFS_F_DIRTY). It's possible for inlined files to be interleaved with writes to other files.

---

This PR also adds LFS_EMUBD_POWERLOSS_OOO to `lfs_emubd`, which tells `lfs_emubd` to try to break any order-dependent code on powerloss. This should prevent a regression in the future.

Found by @MFaehling and @alex31
Related issues: https://github.com/littlefs-project/littlefs/issues/822, https://github.com/littlefs-project/littlefs/issues/936