### PR TITLE
Feature for adding uncommitted close to withdraw previous writes

### DIFF
--- a/lfs.h
+++ b/lfs.h
@@ -598,6 +598,15 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
 // Returns a negative error code on failure.
 int lfs_file_close(lfs_t *lfs, lfs_file_t *file);
 
+// Close a file
+//
+// Any pending writes are withdrawn.
+// If desired a previous sync call is necesarry to write pending writes out to the storage.
+// Releases any allocated resources.
+//
+// Returns a negative error code on failure.
+int lfs_file_uncommitted_close(lfs_t *lfs, lfs_file_t *file);
+
 // Synchronize a file on storage
 //
 // Any pending writes are written out to storage.


### PR DESCRIPTION
Currently, changes made by writing to a file only become valid by a commit when the file is closed in accordance to atomic operations. 
Scenarios are conceivable in which the intended writing to a file is not committed, but the underlying housekeeping leaves no memory leaks by closing the file properly. e.g. when reading back, it is determined that the temporarily written data is logically corrupt because, for example, a higher-level integrity check failed. It would then be desirable for the previous state of the file to be retained (without having to write to a new file and move it afterwards).

To support the withdrawal of an ACID transaction (https://en.wikipedia.org/wiki/ACID), I would like to introduce the following proposal and introduce a new close function without committing the written changes.
