### PR TITLE
Limit release script to only draft releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,7 +254,7 @@ jobs:
               tag_name: env.LFS_VERSION,
               name: env.LFS_VERSION | rtrimstr(".0"),
               target_commitish: "${{github.event.workflow_run.head_sha}}",
-              draft: env.LFS_VERSION | endswith(".0"),
+              draft: true,
               body: $release,
             }' | tee /dev/stderr)"
 


### PR DESCRIPTION
We probably always want a human involved in the final step of publishing a release. 1. To allow editing of the release notes before notifying users, and 2. to avoid any issues with rogue scripts (who doesn't want 1000 release notifications?).

Especially now that releases may trigger additional post-release scripts.