### PR TITLE
Allow CRC-32 match value override

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -1775,7 +1775,7 @@ static int lfs_dir_commitcrc(lfs_t *lfs, struct lfs_commit *commit) {
         return err;
     }
 
-    if (crc != 0) {
+    if (crc != LFS_CRC_MATCH) {
         return LFS_ERR_CORRUPT;
     }
 
@@ -5401,7 +5401,7 @@ static int lfs1_dir_fetch(lfs_t *lfs,
             return err;
         }
 
-        if (crc != 0) {
+        if (crc != LFS_CRC_MATCH) {
             continue;
         }
 

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -211,6 +211,12 @@ static inline uint32_t lfs_tobe32(uint32_t a) {
     return lfs_frombe32(a);
 }
 
+// Specify CRC-32 implementation specific match value that you get when
+// computing CRC over a payload and its CRC.
+#ifndef LFS_CRC_MATCH
+#define LFS_CRC_MATCH 0x00000000
+#endif
+
 // Calculate CRC-32 with polynomial = 0x04c11db7
 #ifdef LFS_CRC
 uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size) {


### PR DESCRIPTION
LFS format failed because CRC=0 is, in the general case, a wrong value to test against. For example, valid zlib CRC-32 match value would be 0x2144df1c.