### PR TITLE
add library.json to support compilation as platformio library

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,17 @@
+{
+  "name": "littlefs",
+  "description": "A little fail-safe filesystem designed for microcontrollers",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/littlefs-project/littlefs"
+  },
+  "homepage": "https://github.com/littlefs-project/littlefs",
+  "license": "BSD-3-Clause",
+  "platforms": "*",
+  "frameworks": "*",
+  "build": {
+    "srcDir": ".",
+    "srcFilter": "+<*> -<benches> -<bd> -<tests> -<runners> -<scripts>",
+    "unflags": "-Wshadow"
+  }
+}


### PR DESCRIPTION
This is a simple PR to add compilation support as a platformio library.  The only thing I needed to add was a custom option to avoid the usage of `Wshadow` when compiling littlefs.

To use this in a project, it can be referenced via a URL in the project's `platformio.ini` with the following text

```
lib_deps =
    https://github.com/littlefs-project/littlefs#{githash/tag}
```
