### PR TITLE
Allow sync to be NULL when not needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ If your storage caches writes, make sure that the provided `sync` function
 flushes all the data to memory and ensures that the next read fetches the data
 from memory, otherwise data integrity can not be guaranteed. If the `write`
 function does not perform caching, and therefore each `read` or `write` call
-hits the memory, the `sync` function can simply return 0.
+hits the memory, the `sync` function can be `NULL` or simply return 0.
 
 ## Design
 

--- a/lfs.c
+++ b/lfs.c
@@ -217,8 +217,10 @@ static int lfs_bd_sync(lfs_t *lfs,
         return err;
     }
 
-    err = lfs->cfg->sync(lfs->cfg);
-    LFS_ASSERT(err <= 0);
+    if (lfs->cfg->sync != NULL) {
+        err = lfs->cfg->sync(lfs->cfg);
+        LFS_ASSERT(err <= 0);
+    }
     return err;
 }
 #endif

--- a/lfs.h
+++ b/lfs.h
@@ -178,6 +178,7 @@ struct lfs_config {
 
     // Sync the state of the underlying block device. Negative error codes
     // are propagated to the user.
+    // May be NULL if the write does not perform caching.
     int (*sync)(const struct lfs_config *c);
 
 #ifdef LFS_THREADSAFE


### PR DESCRIPTION
When using non-caching storage, the user can omit the `sync` function in `struct lfs_config`.

This would be more intuitive. 

(After spending hours debugging why the program stuck after `prog` is called... I went back to the doc and see the descriptions about `sync`. It says "simply return 0" which I thought to be "simply 0". Is it just me?)