### PR TITLE
gha: Fix x86-only statuses

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,7 +273,6 @@ jobs:
             }' | tee status/$(basename $f .csv).json
           done
       - name: upload-status-sizes
-        if: ${{matrix.arch == 'x86_64'}}
         uses: actions/upload-artifact@v4
         with:
           name: status-sizes-${{matrix.arch}}


### PR DESCRIPTION
Looks like I missed a line during refactoring, resulted in only x86 sizes being reported in GitHub statuses.

\< Insert rant about GHA making a mess of commit histories \>

Related: https://github.com/littlefs-project/littlefs/pull/1026