### PR TITLE
Fix for "unsafe use of type bool" warning when compiling with MSVC.

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -2558,7 +2558,7 @@ static int lfs_dir_orphaningcommit(lfs_t *lfs, lfs_mdir_t *dir,
         if (err != LFS_ERR_NOENT) {
             if (lfs_gstate_hasorphans(&lfs->gstate)) {
                 // next step, clean up orphans
-                err = lfs_fs_preporphans(lfs, -hasparent);
+                err = lfs_fs_preporphans(lfs, -(int8_t)hasparent);
                 if (err) {
                     return err;
                 }


### PR DESCRIPTION
Using negate on a bool causes a warning when compiling with MSVC 19.X:
```
littlefs\lfs.c(2561): error C2220: the following warning is treated as an error
littlefs\lfs.c(2561): warning C4804: '-': unsafe use of type 'bool' in operation
```