### PR TITLE
Changed cast to correct type when trace is enabled for filebd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -374,6 +374,29 @@ jobs:
         run: |
           CFLAGS="$CFLAGS -DLFS_NO_INTRINSICS" make test
 
+  # run with all trace options enabled to at least make sure these
+  # all compile
+  test-yes-trace:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: install
+        run: |
+          # need a few things
+          sudo apt-get update -qq
+          sudo apt-get install -qq gcc python3 python3-pip
+          pip3 install toml
+          gcc --version
+          python3 --version
+      - name: test-yes-trace
+        run: |
+          CFLAGS="$CFLAGS \
+            -DLFS_YES_TRACE \
+            -DLFS_RAMBD_YES_TRACE \
+            -DLFS_FILEBD_YES_TRACE \
+            -DLFS_RAMBD_YES_TRACE" \
+            make test
+
   # run LFS_MULTIVERSION tests
   test-multiversion:
     runs-on: ubuntu-latest

--- a/bd/lfs_filebd.c
+++ b/bd/lfs_filebd.c
@@ -133,7 +133,7 @@ int lfs_filebd_prog(const struct lfs_config *cfg, lfs_block_t block,
 
 int lfs_filebd_erase(const struct lfs_config *cfg, lfs_block_t block) {
     LFS_FILEBD_TRACE("lfs_filebd_erase(%p, 0x%"PRIx32" (%"PRIu32"))",
-            (void*)cfg, block, ((lfs_file_t*)cfg->context)->cfg->erase_size);
+            (void*)cfg, block, ((lfs_filebd_t*)cfg->context)->cfg->erase_size);
     lfs_filebd_t *bd = cfg->context;
 
     // check if erase is valid


### PR DESCRIPTION
This does not compile when LFS_FILEBD_YES_TRACE is set, due to a cast to a `lfs_file_t` instead of `lfs_filebd_t`