### PR TITLE
adapt the linker sections usage to mach-o

### DIFF
--- a/runners/bench_runner.c
+++ b/runners/bench_runner.c
@@ -123,8 +123,13 @@ typedef struct bench_id {
 
 
 // bench suites are linked into a custom ld section
+#if defined(__APPLE__)
+extern struct bench_suite __start__bench_suites __asm("section$start$__DATA$_bench_suites");
+extern struct bench_suite __stop__bench_suites __asm("section$end$__DATA$_bench_suites");
+#else
 extern struct bench_suite __start__bench_suites;
 extern struct bench_suite __stop__bench_suites;
+#endif
 
 const struct bench_suite *bench_suites = &__start__bench_suites;
 #define BENCH_SUITE_COUNT \

--- a/runners/test_runner.c
+++ b/runners/test_runner.c
@@ -136,8 +136,13 @@ typedef struct test_id {
 
 
 // test suites are linked into a custom ld section
+#if defined(__APPLE__)
+extern struct test_suite __start__test_suites __asm("section$start$__DATA$_test_suites");
+extern struct test_suite __stop__test_suites __asm("section$end$__DATA$_test_suites");
+#else
 extern struct test_suite __start__test_suites;
 extern struct test_suite __stop__test_suites;
+#endif
 
 const struct test_suite *test_suites = &__start__test_suites;
 #define TEST_SUITE_COUNT \

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -404,12 +404,15 @@ def compile(bench_paths, **args):
                         f.writeln()
 
                 # create suite struct
-                #
+                f.writeln('#if defined(__APPLE__)')
+                f.writeln('__attribute__((section("__DATA,_bench_suites")))')
+                f.writeln('#else')
                 # note we place this in the custom bench_suites section with
                 # minimum alignment, otherwise GCC ups the alignment to
                 # 32-bytes for some reason
                 f.writeln('__attribute__((section("_bench_suites"), '
                     'aligned(1)))')
+                f.writeln('#endif')
                 f.writeln('const struct bench_suite __bench__%s__suite = {'
                     % suite.name)
                 f.writeln(4*' '+'.name = "%s",' % suite.name)

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -412,12 +412,15 @@ def compile(test_paths, **args):
                         f.writeln()
 
                 # create suite struct
-                #
+                f.writeln('#if defined(__APPLE__)')
+                f.writeln('__attribute__((section("__DATA,_test_suites")))')
+                f.writeln('#else')
                 # note we place this in the custom test_suites section with
                 # minimum alignment, otherwise GCC ups the alignment to
                 # 32-bytes for some reason
                 f.writeln('__attribute__((section("_test_suites"), '
                     'aligned(1)))')
+                f.writeln('#endif')
                 f.writeln('const struct test_suite __test__%s__suite = {'
                     % suite.name)
                 f.writeln(4*' '+'.name = "%s",' % suite.name)


### PR DESCRIPTION
"make test" on macOS:

```
using runner: ./runners/test_runner
found 19 suites, 188 cases, 11242/11770 permutations

running test_alloc: 12/12 cases, 207/207 perms
running test_attrs: 4/4 cases, 20/20 perms
running test_badblocks: 4/4 cases, 300/300 perms
running test_bd: 5/5 cases, 85/85 perms
running test_compat: 17/17 cases, 205/205 perms
running test_dirs: 15/15 cases, 450/450 perms, 1756pls!
running test_entries: 8/8 cases, 32/32 perms
running test_evil: 8/8 cases, 105/105 perms
running test_exhaustion: 5/5 cases, 85/85 perms
running test_files: 10/10 cases, 7155/7155 perms, 9410pls!
running test_interspersed: 4/4 cases, 190/190 perms, 2835pls!
running test_move: 17/17 cases, 161/161 perms, 157pls!
running test_orphans: 6/6 cases, 50/50 perms, 846pls!
running test_paths: 33/33 cases, 325/325 perms
running test_powerloss: 2/2 cases, 21/21 perms
running test_relocations: 4/4 cases, 68/68 perms, 1612pls!
running test_seek: 10/10 cases, 195/195 perms, 1050pls!
running test_superblocks: 17/17 cases, 318/318 perms, 1437pls!
running test_truncate: 7/7 cases, 1270/1270 perms, 9691pls!

done: 11242/11242 passed, 0/11242 failed, 28794pls!, in 585.76s
```