### PR TITLE
Fix filesystem gets corrupted

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -1185,7 +1185,7 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
                 maybeerased = (lfs_tag_type2(ptag) == LFS_TYPE_CCRC);
                 break;
             // out of range?
-            } else if (off + lfs_tag_dsize(tag) > lfs->cfg->block_size) {
+            } else if (off + lfs_tag_dsize(tag) >= lfs->cfg->block_size) {
                 break;
             }
 


### PR DESCRIPTION
A fix that worked for our project using LittleFS with STM32H7XX when facing similar issues like the https://github.com/littlefs-project/littlefs/issues/461

Steps to reproduce in our project:

It was noticed that when copying files to the flash then eventually the fs gets corrupted.

After this finding a stress testing was implemented and additional traces added to littlefs. With the testing it was noticed the off by one issue in a block boundary check.

This commit fixes the off by one check and all corruption traces were fixed. The filesystem does not end up unmountable (corrupted) anymore after this fix.