### PR TITLE
Add support for shrinking a filesystem

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -374,6 +374,22 @@ jobs:
         run: |
           CFLAGS="$CFLAGS -DLFS_NO_INTRINSICS" make test
 
+  test-shrink:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: install
+        run: |
+          # need a few things
+          sudo apt-get update -qq
+          sudo apt-get install -qq gcc python3 python3-pip
+          pip3 install toml
+          gcc --version
+          python3 --version
+      - name: test-no-intrinsics
+        run: |
+          CFLAGS="$CFLAGS -DLFS_SHRINKIFCHEAP" make test
+
   # run with all trace options enabled to at least make sure these
   # all compile
   test-yes-trace:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -388,7 +388,7 @@ jobs:
           python3 --version
       - name: test-no-intrinsics
         run: |
-          CFLAGS="$CFLAGS -DLFS_SHRINKIFCHEAP" make test
+          CFLAGS="$CFLAGS -DLFS_SHRINKNONRELOCATING" make test
 
   # run with all trace options enabled to at least make sure these
   # all compile

--- a/lfs.c
+++ b/lfs.c
@@ -5233,7 +5233,7 @@ static int lfs_fs_gc_(lfs_t *lfs) {
 #endif
 
 #ifndef LFS_READONLY
-#ifdef LFS_SHRINKIFCHEAP
+#ifdef LFS_SHRINKNONRELOCATING
 static int lfs_shrink_checkblock(void * data, lfs_block_t block) {
     lfs_size_t threshold = *((lfs_size_t *) data);
     if (block >= threshold) {
@@ -5251,11 +5251,11 @@ static int lfs_fs_grow_(lfs_t *lfs, lfs_size_t block_count) {
     }
 
     
-#ifndef LFS_SHRINKIFCHEAP
+#ifndef LFS_SHRINKNONRELOCATING
     // shrinking is not supported
     LFS_ASSERT(block_count >= lfs->block_count);
 #endif
-#ifdef LFS_SHRINKIFCHEAP
+#ifdef LFS_SHRINKNONRELOCATING
     lfs_block_t threshold = block_count;
     err = lfs_fs_traverse_(lfs, lfs_shrink_checkblock, &threshold, true);
     if (err) {

--- a/lfs.c
+++ b/lfs.c
@@ -5234,8 +5234,8 @@ static int lfs_fs_gc_(lfs_t *lfs) {
 
 #ifndef LFS_READONLY
 #ifdef LFS_SHRINKNONRELOCATING
-static int lfs_shrink_checkblock(void * data, lfs_block_t block) {
-    lfs_size_t threshold = *((lfs_size_t *) data);
+static int lfs_shrink_checkblock(void *data, lfs_block_t block) {
+    lfs_size_t threshold = *((lfs_size_t*)data);
     if (block >= threshold) {
         return LFS_ERR_NOTEMPTY;
     }
@@ -5256,10 +5256,11 @@ static int lfs_fs_grow_(lfs_t *lfs, lfs_size_t block_count) {
     LFS_ASSERT(block_count >= lfs->block_count);
 #endif
 #ifdef LFS_SHRINKNONRELOCATING
-    lfs_block_t threshold = block_count;
-    err = lfs_fs_traverse_(lfs, lfs_shrink_checkblock, &threshold, true);
-    if (err) {
-        return err;
+    if (block_count < lfs->block_count) {
+        err = lfs_fs_traverse_(lfs, lfs_shrink_checkblock, &block_count, true);
+        if (err) {
+            return err;
+        }
     }
 #endif
 

--- a/lfs.h
+++ b/lfs.h
@@ -766,11 +766,11 @@ int lfs_fs_gc(lfs_t *lfs);
 // Grows the filesystem to a new size, updating the superblock with the new
 // block count.
 //
-// if LFS_SHRINKIFCHEAP is defined, this function will also accept
+// If LFS_SHRINKIFCHEAP is defined, this function will also accept
 // block_counts smaller than the current configuration, after checking
 // that none of the blocks that are being removed are in use.
-//
-// Note: This is irreversible.
+// Note that littlefs's pseudorandom block allocation means that
+// this is very unlikely to work in the general case.
 //
 // Returns a negative error code on failure.
 int lfs_fs_grow(lfs_t *lfs, lfs_size_t block_count);

--- a/lfs.h
+++ b/lfs.h
@@ -766,21 +766,14 @@ int lfs_fs_gc(lfs_t *lfs);
 // Grows the filesystem to a new size, updating the superblock with the new
 // block count.
 //
+// if LFS_SHRINKIFCHEAP is defined, this function will also accept
+// block_counts smaller than the current configuration, after checking
+// that none of the blocks that are being removed are in use.
+//
 // Note: This is irreversible.
 //
 // Returns a negative error code on failure.
 int lfs_fs_grow(lfs_t *lfs, lfs_size_t block_count);
-#endif
-
-#ifndef LFS_READONLY
-// Shrinks the filesystem to a new size, updating the superblock with the new
-// block count.
-//
-// Note: This first checks that none of the blocks that are being removed are in use
-// and will fail if it is the case
-//
-// Returns a negative error code on failure.
-int lfs_fs_shrink(lfs_t *lfs, lfs_size_t block_count);
 #endif
 
 #ifndef LFS_READONLY

--- a/lfs.h
+++ b/lfs.h
@@ -773,6 +773,17 @@ int lfs_fs_grow(lfs_t *lfs, lfs_size_t block_count);
 #endif
 
 #ifndef LFS_READONLY
+// Shrinks the filesystem to a new size, updating the superblock with the new
+// block count.
+//
+// Note: This first checks that none of the blocks that are being removed are in use
+// and will fail if it is the case
+//
+// Returns a negative error code on failure.
+int lfs_fs_shrink(lfs_t *lfs, lfs_size_t block_count);
+#endif
+
+#ifndef LFS_READONLY
 #ifdef LFS_MIGRATE
 // Attempts to migrate a previous version of littlefs
 //

--- a/lfs.h
+++ b/lfs.h
@@ -766,7 +766,7 @@ int lfs_fs_gc(lfs_t *lfs);
 // Grows the filesystem to a new size, updating the superblock with the new
 // block count.
 //
-// If LFS_SHRINKIFCHEAP is defined, this function will also accept
+// If LFS_SHRINKNONRELOCATING is defined, this function will also accept
 // block_counts smaller than the current configuration, after checking
 // that none of the blocks that are being removed are in use.
 // Note that littlefs's pseudorandom block allocation means that

--- a/tests/test_shrink.toml
+++ b/tests/test_shrink.toml
@@ -7,7 +7,7 @@ code = '''
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
-    lfs_fs_shrink(&lfs, AFTER_BLOCK_COUNT) => 0;
+    lfs_fs_grow(&lfs, AFTER_BLOCK_COUNT) => 0;
     lfs_unmount(&lfs);
     if (BLOCK_COUNT != AFTER_BLOCK_COUNT) {
         lfs_mount(&lfs, cfg) => LFS_ERR_INVAL;
@@ -46,7 +46,7 @@ code = '''
         lfs_file_close(&lfs, &file) => 0;
     }
 
-    int err = lfs_fs_shrink(&lfs, AFTER_BLOCK_COUNT);
+    int err = lfs_fs_grow(&lfs, AFTER_BLOCK_COUNT);
     if (err == 0) {
         for (int i = 0; i < FILES_COUNT + 1; i++) {
             lfs_file_t file;

--- a/tests/test_shrink.toml
+++ b/tests/test_shrink.toml
@@ -2,8 +2,10 @@
 [cases.test_shrink_simple]
 defines.BLOCK_COUNT = [10, 15, 20]
 defines.AFTER_BLOCK_COUNT = [5, 10, 15, 19]
+   
 if = "AFTER_BLOCK_COUNT <= BLOCK_COUNT"
 code = '''
+#ifdef LFS_SHRINKIFCHEAP
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
@@ -18,6 +20,7 @@ code = '''
     lfs2.cfg = &cfg2;
     lfs_mount(&lfs2, &cfg2) => 0;
     lfs_unmount(&lfs2) => 0;
+#endif
 '''
 
 # shrinking full
@@ -27,6 +30,7 @@ defines.AFTER_BLOCK_COUNT = [5, 7, 10, 12, 15, 17, 20]
 defines.FILES_COUNT = [7, 8, 9, 10]
 if = "AFTER_BLOCK_COUNT <= BLOCK_COUNT && FILES_COUNT + 2 < BLOCK_COUNT"
 code = '''
+#ifdef LFS_SHRINKIFCHEAP
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     // create FILES_COUNT files of BLOCK_SIZE - 50 bytes (to avoid inlining)
@@ -101,4 +105,5 @@ code = '''
         }
         lfs_unmount(&lfs2);
     }
+#endif
 '''

--- a/tests/test_shrink.toml
+++ b/tests/test_shrink.toml
@@ -5,7 +5,7 @@ defines.AFTER_BLOCK_COUNT = [5, 10, 15, 19]
    
 if = "AFTER_BLOCK_COUNT <= BLOCK_COUNT"
 code = '''
-#ifdef LFS_SHRINKIFCHEAP
+#ifdef LFS_SHRINKNONRELOCATING
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
@@ -30,7 +30,7 @@ defines.AFTER_BLOCK_COUNT = [5, 7, 10, 12, 15, 17, 20]
 defines.FILES_COUNT = [7, 8, 9, 10]
 if = "AFTER_BLOCK_COUNT <= BLOCK_COUNT && FILES_COUNT + 2 < BLOCK_COUNT"
 code = '''
-#ifdef LFS_SHRINKIFCHEAP
+#ifdef LFS_SHRINKNONRELOCATING
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     // create FILES_COUNT files of BLOCK_SIZE - 50 bytes (to avoid inlining)

--- a/tests/test_shrink.toml
+++ b/tests/test_shrink.toml
@@ -1,0 +1,104 @@
+# simple shrink
+[cases.test_shrink_simple]
+defines.BLOCK_COUNT = [10, 15, 20]
+defines.AFTER_BLOCK_COUNT = [5, 10, 15, 19]
+if = "AFTER_BLOCK_COUNT <= BLOCK_COUNT"
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_shrink(&lfs, AFTER_BLOCK_COUNT) => 0;
+    lfs_unmount(&lfs);
+    if (BLOCK_COUNT != AFTER_BLOCK_COUNT) {
+        lfs_mount(&lfs, cfg) => LFS_ERR_INVAL;
+    }
+    lfs_t lfs2 = lfs;
+    struct lfs_config cfg2 = *cfg;
+    cfg2.block_count = AFTER_BLOCK_COUNT;
+    lfs2.cfg = &cfg2;
+    lfs_mount(&lfs2, &cfg2) => 0;
+    lfs_unmount(&lfs2) => 0;
+'''
+
+# shrinking full
+[cases.test_shrink_full]
+defines.BLOCK_COUNT = [10, 15, 20]
+defines.AFTER_BLOCK_COUNT = [5, 7, 10, 12, 15, 17, 20]
+defines.FILES_COUNT = [7, 8, 9, 10]
+if = "AFTER_BLOCK_COUNT <= BLOCK_COUNT && FILES_COUNT + 2 < BLOCK_COUNT"
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    // create FILES_COUNT files of BLOCK_SIZE - 50 bytes (to avoid inlining)
+    lfs_mount(&lfs, cfg) => 0;
+    for (int i = 0; i < FILES_COUNT + 1; i++) {
+        lfs_file_t file;
+        char path[1024];
+        sprintf(path, "file_%03d", i);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        char wbuffer[BLOCK_SIZE];
+        memset(wbuffer, 'b', BLOCK_SIZE);
+        // Ensure one block is taken per file, but that files are not inlined.
+        lfs_size_t size = BLOCK_SIZE - 0x40;
+        sprintf(wbuffer, "Hi %03d", i);
+        lfs_file_write(&lfs, &file, wbuffer, size) => size;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    int err = lfs_fs_shrink(&lfs, AFTER_BLOCK_COUNT);
+    if (err == 0) {
+        for (int i = 0; i < FILES_COUNT + 1; i++) {
+            lfs_file_t file;
+            char path[1024];
+            sprintf(path, "file_%03d", i);
+            lfs_file_open(&lfs, &file, path,
+                    LFS_O_RDONLY ) => 0;
+            lfs_size_t size = BLOCK_SIZE - 0x40;
+            char wbuffer[size];
+            char wbuffer_ref[size];
+            // Ensure one block is taken per file, but that files are not inlined.
+            memset(wbuffer_ref, 'b', size);
+            sprintf(wbuffer_ref, "Hi %03d", i);
+            lfs_file_read(&lfs, &file, wbuffer, BLOCK_SIZE) => size;
+            lfs_file_close(&lfs, &file) => 0;
+            for (lfs_size_t j = 0; j < size; j++) {
+                wbuffer[j] => wbuffer_ref[j];
+            }
+        }
+    } else {
+        assert(err == LFS_ERR_NOTEMPTY);
+    }
+
+    lfs_unmount(&lfs) => 0;
+    if (err == 0 ) {
+        if ( AFTER_BLOCK_COUNT != BLOCK_COUNT ) {
+            lfs_mount(&lfs, cfg) => LFS_ERR_INVAL;
+        }
+
+        lfs_t lfs2 = lfs;
+        struct lfs_config cfg2 = *cfg;
+        cfg2.block_count = AFTER_BLOCK_COUNT;
+        lfs2.cfg = &cfg2;
+        lfs_mount(&lfs2, &cfg2) => 0;
+        for (int i = 0; i < FILES_COUNT + 1; i++) {
+            lfs_file_t file;
+            char path[1024];
+            sprintf(path, "file_%03d", i);
+            lfs_file_open(&lfs2, &file, path,
+                    LFS_O_RDONLY ) => 0;
+            lfs_size_t size = BLOCK_SIZE - 0x40;
+            char wbuffer[size];
+            char wbuffer_ref[size];
+            // Ensure one block is taken per file, but that files are not inlined.
+            memset(wbuffer_ref, 'b', size);
+            sprintf(wbuffer_ref, "Hi %03d", i);
+            lfs_file_read(&lfs2, &file, wbuffer, BLOCK_SIZE) => size;
+            lfs_file_close(&lfs2, &file) => 0;
+            for (lfs_size_t j = 0; j < size; j++) {
+                wbuffer[j] => wbuffer_ref[j];
+            }
+        }
+        lfs_unmount(&lfs2);
+    }
+'''

--- a/tests/test_superblocks.toml
+++ b/tests/test_superblocks.toml
@@ -531,7 +531,7 @@ defines.BLOCK_COUNT = 'ERASE_COUNT'
 defines.BLOCK_COUNT_2 = ['ERASE_COUNT/2', 'ERASE_COUNT/4', '2']
 defines.KNOWN_BLOCK_COUNT = [true, false]
 code = '''
-#ifdef LFS_SHRINKIFCHEAP
+#ifdef LFS_SHRINKNONRELOCATING
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
 

--- a/tests/test_superblocks.toml
+++ b/tests/test_superblocks.toml
@@ -531,6 +531,7 @@ defines.BLOCK_COUNT = 'ERASE_COUNT'
 defines.BLOCK_COUNT_2 = ['ERASE_COUNT/2', 'ERASE_COUNT/4', '2']
 defines.KNOWN_BLOCK_COUNT = [true, false]
 code = '''
+#ifdef LFS_SHRINKIFCHEAP
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
 
@@ -628,6 +629,7 @@ code = '''
     lfs_file_close(&lfs, &file) => 0;
     assert(memcmp(buffer, "hello!", 6) == 0);
     lfs_unmount(&lfs) => 0;
+#endif
 '''
 
 # test that metadata_max does not cause problems for superblock compaction

--- a/tests/test_superblocks.toml
+++ b/tests/test_superblocks.toml
@@ -550,7 +550,7 @@ code = '''
 
     // same size is a noop
     lfs_mount(&lfs, cfg) => 0;
-    lfs_fs_shrink(&lfs, BLOCK_COUNT) => 0;
+    lfs_fs_grow(&lfs, BLOCK_COUNT) => 0;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
     assert(fsinfo.block_size == BLOCK_SIZE);
     assert(fsinfo.block_count == BLOCK_COUNT);
@@ -564,7 +564,7 @@ code = '''
 
     // grow to new size
     lfs_mount(&lfs, cfg) => 0;
-    lfs_fs_shrink(&lfs, BLOCK_COUNT_2) => 0;
+    lfs_fs_grow(&lfs, BLOCK_COUNT_2) => 0;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
     assert(fsinfo.block_size == BLOCK_SIZE);
     assert(fsinfo.block_count == BLOCK_COUNT_2);
@@ -594,7 +594,7 @@ code = '''
 
     // same size is a noop
     lfs_mount(&lfs, cfg) => 0;
-    lfs_fs_shrink(&lfs, BLOCK_COUNT_2) => 0;
+    lfs_fs_grow(&lfs, BLOCK_COUNT_2) => 0;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
     assert(fsinfo.block_size == BLOCK_SIZE);
     assert(fsinfo.block_count == BLOCK_COUNT_2);

--- a/tests/test_superblocks.toml
+++ b/tests/test_superblocks.toml
@@ -524,6 +524,112 @@ code = '''
     lfs_unmount(&lfs) => 0;
 '''
 
+
+# mount and grow the filesystem
+[cases.test_superblocks_shrink]
+defines.BLOCK_COUNT = 'ERASE_COUNT'
+defines.BLOCK_COUNT_2 = ['ERASE_COUNT/2', 'ERASE_COUNT/4', '2']
+defines.KNOWN_BLOCK_COUNT = [true, false]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+
+    if (KNOWN_BLOCK_COUNT) {
+        cfg->block_count = BLOCK_COUNT;
+    } else {
+        cfg->block_count = 0;
+    }
+
+    // mount with block_size < erase_size
+    lfs_mount(&lfs, cfg) => 0;
+    struct lfs_fsinfo fsinfo;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT);
+    lfs_unmount(&lfs) => 0;
+
+    // same size is a noop
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_shrink(&lfs, BLOCK_COUNT) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT);
+    lfs_unmount(&lfs) => 0;
+
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT);
+    lfs_unmount(&lfs) => 0;
+
+    // grow to new size
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_shrink(&lfs, BLOCK_COUNT_2) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT_2);
+    lfs_unmount(&lfs) => 0;
+
+    if (KNOWN_BLOCK_COUNT) {
+        cfg->block_count = BLOCK_COUNT_2;
+    } else {
+        cfg->block_count = 0;
+    }
+
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT_2);
+    lfs_unmount(&lfs) => 0;
+
+    // mounting with the previous size should fail
+    cfg->block_count = BLOCK_COUNT;
+    lfs_mount(&lfs, cfg) => LFS_ERR_INVAL;
+
+    if (KNOWN_BLOCK_COUNT) {
+        cfg->block_count = BLOCK_COUNT_2;
+    } else {
+        cfg->block_count = 0;
+    }
+
+    // same size is a noop
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_shrink(&lfs, BLOCK_COUNT_2) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT_2);
+    lfs_unmount(&lfs) => 0;
+
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT_2);
+    lfs_unmount(&lfs) => 0;
+
+    // do some work
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT_2);
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "test",
+            LFS_O_CREAT | LFS_O_EXCL | LFS_O_WRONLY) => 0;
+    lfs_file_write(&lfs, &file, "hello!", 6) => 6;
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_unmount(&lfs) => 0;
+
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT_2);
+    lfs_file_open(&lfs, &file, "test", LFS_O_RDONLY) => 0;
+    uint8_t buffer[256];
+    lfs_file_read(&lfs, &file, buffer, sizeof(buffer)) => 6;
+    lfs_file_close(&lfs, &file) => 0;
+    assert(memcmp(buffer, "hello!", 6) == 0);
+    lfs_unmount(&lfs) => 0;
+'''
+
 # test that metadata_max does not cause problems for superblock compaction
 [cases.test_superblocks_metadata_max]
 defines.METADATA_MAX = [


### PR DESCRIPTION
This PR adds a new `lfs_fs_shrink`, which functions similarly to `lfs_fs_grow`, but supports reducing the block count.

This functions first checks that none of the removed block are in use. If it is the case, it will fail.

Closes #1093 