### PR TITLE
lfs_crc should be static if LFS_CRC is defined

### DIFF
--- a/lfs_util.h
+++ b/lfs_util.h
@@ -231,8 +231,8 @@ static inline uint32_t lfs_tobe32(uint32_t a) {
 
 // Calculate CRC-32 with polynomial = 0x04c11db7
 #ifdef LFS_CRC
-uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size) {
-    return LFS_CRC(crc, buffer, size)
+static inline uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size) {
+    return LFS_CRC(crc, buffer, size);
 }
 #else
 uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size);


### PR DESCRIPTION
If `LFS_CRC` is defined, we define a wrapper function in the header file itself instead of referring to a function implemented later in `lfs_utils.c`. In that case we should declare that wrapper function to be `static` so that we don't end up with multiple definitions of the `lfs_crc` function if the header file (as is quite usual) gets included in multiple compile units.

Additionally it can also be declared `inline` to match the other functions. And, there was a missing semicolon meaning one would have to include an extra semicolon in their `#define` macro to make everything compile without errors. Adding in the semicolon won't break any existing users that already included it themselves.