### PR TITLE
use shutil.move instead of os.rename to move file

### DIFF
--- a/scripts/changeprefix.py
+++ b/scripts/changeprefix.py
@@ -73,7 +73,7 @@ def changefile(from_prefix, to_prefix, from_path, to_path, *,
         shutil.copystat(from_path, to_path)
 
     if to_path_temp:
-        os.rename(to_path, from_path)
+        shutil.move(to_path, from_path)
     elif from_path != '-':
         os.remove(from_path)
 


### PR DESCRIPTION
On my system the temporary directory is a `tmpfs` mount:

```
$ mount | grep /tmp
tmpfs on /tmp type tmpfs (rw,nosuid,nodev,size=31678096k,nr_inodes=1048576,inode64)
```

This breaks `changeprefix.py` because `os.rename` cannot move files across filesystem boundaries:

```
$ ./scripts/changeprefix.py --git lfs lfs2
Traceback (most recent call last):
  File "./scripts/changeprefix.py", line 76, in changefile
    os.rename(to_path, from_path)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
OSError: [Errno 18] Invalid cross-device link: '/tmp/tmp51imc7k8' -> '.gitattributes'
```

A simple fix is to use `shutil.move` which does handle this correctly.