### PR TITLE
make: Add missing BUILD_DEP include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -475,6 +475,7 @@ benchmarks-diff: $(BENCH_CSV)
 # rules
 -include $(DEP)
 -include $(TEST_DEP)
+-include $(BENCH_DEP)
 .SUFFIXES:
 .SECONDARY:
 


### PR DESCRIPTION
This was preventing bench modifications from triggering relevant bench-runner rebuilds.