### PR TITLE
perf: gc might try to populate the lookahead buffer each time

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -5225,7 +5225,9 @@ static int lfs_fs_gc_(lfs_t *lfs) {
     }
 
     // try to populate the lookahead buffer, unless it's already full
-    if (lfs->lookahead.size < lfs_min(8 * lfs->cfg->lookahead_size, lfs->block_count)) {
+    if (lfs->lookahead.size < lfs_min(
+            8 * lfs->cfg->lookahead_size,
+            lfs->block_count)) {
         err = lfs_alloc_scan(lfs);
         if (err) {
             return err;

--- a/lfs.c
+++ b/lfs.c
@@ -5225,7 +5225,7 @@ static int lfs_fs_gc_(lfs_t *lfs) {
     }
 
     // try to populate the lookahead buffer, unless it's already full
-    if (lfs->lookahead.size < 8*lfs->cfg->lookahead_size) {
+    if (lfs->lookahead.size < lfs_min(8 * lfs->cfg->lookahead_size, lfs->block_count)) {
         err = lfs_alloc_scan(lfs);
         if (err) {
             return err;


### PR DESCRIPTION
Sorry my English is very poor, so I use machine translation.
When the user incorrectly sets lookahead_size, if lookahead_size > (block_count / 8), gc might try to populate the lookahead buffer each time.
I'm not sure if this PR is the optimal solution. Perhaps it should help users set the correct value during the mount stage.
Because similar processing is also done in the lfs_format_ and lfs_alloc_scan functions, in fact, this processing can be completely optimized out.