### PR TITLE
fix: add missing return causing uninitialized reads

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -1279,6 +1279,7 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
                     if (err == LFS_ERR_CORRUPT) {
                         break;
                     }
+                    return err;
                 }
 
                 lfs_fcrc_fromle32(&fcrc);


### PR DESCRIPTION
If lfs_bd_read fails, lfs_fcrc_fromle32 will read uninitialized memory, and hasfcrc will be set to true.

This may end up in a "working" state later due to crcs not matching. but it's hard to follow if that woud be the case.