### PR TITLE
fix: compact when dir count hits 0x3ff

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -2264,7 +2264,7 @@ static int lfs_dir_relocatingcommit(lfs_t *lfs, lfs_mdir_t *dir,
         }
     }
 
-    if (dir->erased || dir->count >= 0xff) {
+    if (dir->erased && dir->count < 0xff) {
         // try to commit
         struct lfs_commit commit = {
             .block = dir->pair[0],

--- a/lfs.c
+++ b/lfs.c
@@ -2333,6 +2333,10 @@ static int lfs_dir_relocatingcommit(lfs_t *lfs, lfs_mdir_t *dir,
         lfs->gdisk = lfs->gstate;
         lfs->gdelta = (lfs_gstate_t){0};
 
+        if(dir->count == 0x3ff)
+        {
+            goto compact;
+        }
         goto fixmlist;
     }
 

--- a/lfs.c
+++ b/lfs.c
@@ -2264,7 +2264,7 @@ static int lfs_dir_relocatingcommit(lfs_t *lfs, lfs_mdir_t *dir,
         }
     }
 
-    if (dir->erased) {
+    if (dir->erased || dir->count >= 0xff) {
         // try to commit
         struct lfs_commit commit = {
             .block = dir->pair[0],
@@ -2333,10 +2333,6 @@ static int lfs_dir_relocatingcommit(lfs_t *lfs, lfs_mdir_t *dir,
         lfs->gdisk = lfs->gstate;
         lfs->gdelta = (lfs_gstate_t){0};
 
-        if(dir->count == 0x3ff)
-        {
-            goto compact;
-        }
         goto fixmlist;
     }
 


### PR DESCRIPTION
When dealing with large block sizes (128KiB, for example) and lots of small files (64 bytes and smaller, in the case of 128KiB block sizes), it's possible to run into the constraint where it seems dir->count can't exceed 1023. For example, here https://github.com/littlefs-project/littlefs/blob/master/lfs.c#L1372. This can result in cases where you can fail to create new files even though you have plenty of disk space left.