### PR TITLE
Add littlefs-toy to the related projects section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,11 @@ License Identifiers that are here available: http://spdx.org/licenses/
   to create images of the filesystem on your PC. Check if littlefs will fit
   your needs, create images for a later download to the target memory or
   inspect the content of a binary image of the target memory.
-  
+
+- [littlefs-toy] - A command-line tool for creating and working with littlefs
+  images. Uses syntax similar to tar command for ease of use. Supports working
+  on littlefs images embedded inside another file (firmware image, etc).
+
 - [littlefs2-rust] - A Rust wrapper for littlefs. This project allows you
   to use littlefs in a Rust-friendly API, reaping the benefits of Rust's memory
   safety and other guarantees.
@@ -321,6 +325,7 @@ License Identifiers that are here available: http://spdx.org/licenses/
 [littlefs-js]: https://github.com/geky/littlefs-js
 [littlefs-js-demo]:http://littlefs.geky.net/demo.html
 [littlefs-python]: https://pypi.org/project/littlefs-python/
+[littlefs-toy]: https://github.com/tjko/littlefs-toy
 [littlefs2-rust]: https://crates.io/crates/littlefs2
 [nim-littlefs]: https://github.com/Graveflo/nim-littlefs
 [chamelon]: https://github.com/yomimono/chamelon


### PR DESCRIPTION
For your consideration to possibly add in the README.

littlefs-toy is a small command-line tools with _tar_ like syntax for creating and modifying littlefs images. It supports working on littlefs filesystems embedded inside another file (firmware image, etc.) and can auto-detect blocksize when working on existing littlefs images.
