### PR TITLE
Change include style from "" to <>.

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -5,8 +5,8 @@
  * Copyright (c) 2017, Arm Limited. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#include "lfs.h"
-#include "lfs_util.h"
+#include <lfs.h>
+#include <lfs_util.h>
 
 
 // some constants used throughout the code

--- a/lfs_util.c
+++ b/lfs_util.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2017, Arm Limited. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#include "lfs_util.h"
+#include <lfs_util.h>
 
 // Only compile if user does not provide custom config
 #ifndef LFS_CONFIG


### PR DESCRIPTION
This allows using libraries to override headers in order to inject things like custom logging function definitions.
Without this the compiler is always going to pick the headers that are next to the sources.