### PR TITLE
Add null pointer check for lfs_dir_fetchmatch

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -1290,7 +1290,7 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
             }
 
             // found a match for our fetcher?
-            if ((fmask & tag) == (fmask & ftag)) {
+            if ((fmask & tag) == (fmask & ftag) && cb) {
                 int res = cb(data, tag, &(struct lfs_diskoff){
                         dir->pair[0], off+sizeof(tag)});
                 if (res < 0) {


### PR DESCRIPTION
The internal interface of littlfs calls lfs_dir_fetchmatch with a null cb parameter, and lfs_dir_fetchmatch does not internally determine cb, which may directly call and cause the program to crash.

static int lfs_dir_fetch(lfs_t *lfs,
        lfs_mdir_t *dir, const lfs_block_t pair[2]) {
    // note, mask=-1, tag=-1 can never match a tag since this
    // pattern has the invalid bit set
    return (int)lfs_dir_fetchmatch(lfs, dir, pair,
            (lfs_tag_t)-1, (lfs_tag_t)-1, NULL, NULL, NULL);
}