### PR TITLE
Fixes for 'Implicit conversion loses integer precision' warnings.

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -286,7 +286,7 @@ static int lfs_bd_erase(lfs_t *lfs, lfs_block_t block) {
 
 // some operations on paths
 static inline lfs_size_t lfs_path_namelen(const char *path) {
-    return strcspn(path, "/");
+    return (lfs_size_t)strcspn(path, "/");
 }
 
 static inline bool lfs_path_islast(const char *path) {
@@ -1501,7 +1501,7 @@ nextname:
         if (lfs_tag_type3(tag) == LFS_TYPE_DIR) {
             name += strspn(name, "/");
         }
-        lfs_size_t namelen = strcspn(name, "/");
+        lfs_size_t namelen = (lfs_size_t)strcspn(name, "/");
 
         // skip '.'
         if (namelen == 1 && memcmp(name, ".", 1) == 0) {
@@ -1520,7 +1520,7 @@ nextname:
         int depth = 1;
         while (true) {
             suffix += strspn(suffix, "/");
-            sufflen = strcspn(suffix, "/");
+            sufflen = (lfs_size_t)strcspn(suffix, "/");
             if (sufflen == 0) {
                 break;
             }
@@ -1761,7 +1761,7 @@ static int lfs_dir_commitcrc(lfs_t *lfs, struct lfs_commit *commit) {
 
         commit->off = noff;
         // perturb valid bit?
-        commit->ptag = ntag ^ ((0x80UL & ~eperturb) << 24);
+        commit->ptag = ntag ^ ((lfs_tag_t)(0x80 & ~eperturb) << 24);
         // reset crc for next commit
         commit->crc = 0xffffffff;
 


### PR DESCRIPTION
Since `lfs_size_t` is defined as `uint32_t` and not `size_t`, there are a few warnings for conversion from `unsigned long` (64-bit) to `unsigned int` (32-bit) on 64-bit platforms.

```
lfs.c:288:12 Implicit conversion loses integer precision: 'unsigned long' to 'lfs_size_t' (aka 'unsigned int')
lfs.c:1760:29 Implicit conversion loses integer precision: 'unsigned long' to 'lfs_tag_t' (aka 'unsigned int')
```

Perhaps `lfs_size_t` should be defined as `size_t` instead?
