### PR TITLE
Make attribute writing be dependent on attr_count upon close/sync and not upon open

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -3180,8 +3180,6 @@ static int lfs_file_opencfg_(lfs_t *lfs, lfs_file_t *file,
                 err = LFS_ERR_NOSPC;
                 goto cleanup;
             }
-
-            file->flags |= LFS_F_DIRTY;
         }
 #endif
     }
@@ -3441,7 +3439,9 @@ static int lfs_file_sync_(lfs_t *lfs, lfs_file_t *file) {
     }
 
 
-    if ((file->flags & LFS_F_DIRTY) &&
+    if (((file->flags & LFS_F_DIRTY) ||
+            (/* User request attributes write */(file->cfg->attr_count > 0) && (file->flags & LFS_O_WRONLY)))
+            &&
             !lfs_pair_isnull(file->m.pair)) {
         // before we commit metadata, we need sync the disk to make sure
         // data writes don't complete after metadata writes

--- a/lfs.h
+++ b/lfs.h
@@ -351,9 +351,9 @@ struct lfs_file_config {
     // Optional list of custom attributes related to the file. If the file
     // is opened with read access, these attributes will be read from disk
     // during the open call. If the file is opened with write access, the
-    // attributes will be written to disk every file sync or close. This
-    // write occurs atomically with update to the file's contents.
-    //
+    // attributes will be written to disk every file sync or close according
+    // to the attr_count value and attrs content upon close. This write occurs
+    // atomically with update to the file's contents.
     // Custom attributes are uniquely identified by an 8-bit type and limited
     // to LFS_ATTR_MAX bytes. When read, if the stored attribute is smaller
     // than the buffer, it will be padded with zeros. If the stored attribute

--- a/tests/test_attrs.toml
+++ b/tests/test_attrs.toml
@@ -267,6 +267,42 @@ code = '''
     memcmp(buffer, "hello", strlen("hello")) => 0;
     lfs_file_close(&lfs, &file);
     lfs_unmount(&lfs) => 0;
+
+    lfs_mount(&lfs, cfg) => 0;
+    struct lfs_attr attrs4[] = {
+        {'A', buffer,    4},
+    };
+    memset(buffer, 'a', sizeof(buffer));
+    struct lfs_file_config cfg4 = {.attrs=attrs4};
+    lfs_file_open(&lfs, &file, "hello/hello2", LFS_O_WRONLY | LFS_O_CREAT) => 0;
+    lfs_file_close(&lfs, &file);
+
+
+    cfg4.attr_count = 1;
+    lfs_file_opencfg(&lfs, &file, "hello/hello2", LFS_O_WRONLY | LFS_O_RDONLY, &cfg4) => 0;
+    lfs_off_t origin_file_metadata_offset = file.m.off;
+    cfg4.attr_count = 0;
+    lfs_file_sync(&lfs, &file); // No write expected, although that upon opening attr_count was 1
+    lfs_getattr(&lfs, "hello/hello2", 'A', buffer,  4) => LFS_ERR_NOATTR;
+    (file.m.off != origin_file_metadata_offset) => 0; // expecten no write to happen
+    cfg4.attr_count = 1;
+    lfs_file_sync(&lfs, &file); // attributes expected to be written because attr_count is 1, although no write happened
+    lfs_getattr(&lfs, "hello/hello2", 'A', buffer,  4) => 4;
+    lfs_file_close(&lfs, &file);
+
+    memset(buffer, 'b', sizeof(buffer));
+    cfg4.attr_count = 1;
+    lfs_file_opencfg(&lfs, &file, "hello/hello3", LFS_O_WRONLY | LFS_O_CREAT, &cfg4) => 0;
+    lfs_file_sync(&lfs, &file);
+    lfs_getattr(&lfs, "hello/hello3", 'A', buffer,  4) => 4;
+    memcmp(buffer,    "bbbb",      4) => 0;
+    memset(buffer, 'c', sizeof(buffer));
+    lfs_file_sync(&lfs, &file); // attributes expected to be re-written because attr_count is still 1, although no write happened
+    lfs_getattr(&lfs, "hello/hello3", 'A', buffer,  4) => 4;
+    memcmp(buffer,    "cccc",      4) => 0;
+    lfs_file_close(&lfs, &file);
+    lfs_unmount(&lfs) => 0;
+
 '''
 
 [cases.test_attrs_deferred_file]


### PR DESCRIPTION
Current user attributes behavior given upon open to write is bit complicated:
**If attribute count is not 0 upon open:**
At the first sync (or close) after the open things will be written to the disk (in cost of wear etc.) even if user decided not to write attributes and changed attribute count to 0 (maybe wanted to read attributes upon open and according that decided not to update them?).
at next syncs (or close) will write user attributes will be re-written (and changed if user changed them in the buffer) just if the file changed till then.
**If attribute count is 0 upon open:**
syncs (or close) user attributes will be re-written (and changed if user changed them in the buffer) just if the file changed till then.

This is complex behave, and in cases for example that user opened file with READ-WRITE and wanted to read attributes it will cause write to flash even if he decided not to change anything.


**Solution in this fix**
The write of the user attributes will be done if and just if file was opened to write and attribute count is greater than 0 upon the close/sync.

**tests that added (and will fail without this PR):**
1. if upon open attribute count was 1 and upon sync it was 0 and no change done to the file - there was no write to the file metadata (file position stay same)
2. changing attribute count to 1 before sync cause write of the user attributes to the file, even if the file wasn't change (before the fix it happened just in first sync after opening if the attribute count was bigger than 0 upon opening).
3. if multiple syncs happen when attribute count is bigger than 1, each time attributes will be written. (this is reasonable behavior, but user need to be aware of it if fore some reason it calls lots of syncs without any change and the attribute count is bigger than 0 each sync will cause write to the disk)