### PR TITLE
 lfs: guard null callbacks in lfs_dir_fetchmatch

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -1290,7 +1290,7 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
             }
 
             // found a match for our fetcher?
-            if ((fmask & tag) == (fmask & ftag)) {
+            if ((fmask & tag) == (fmask & ftag) && (cb != NULL)) {
                 int res = cb(data, tag, &(struct lfs_diskoff){
                         dir->pair[0], off+sizeof(tag)});
                 if (res < 0) {

--- a/lfs.c
+++ b/lfs.c
@@ -1290,7 +1290,8 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
             }
 
             // found a match for our fetcher?
-            if ((fmask & tag) == (fmask & ftag) && (cb != NULL)) {
+            if ((fmask & tag) == (fmask & ftag)) {
+                LFS_ASSERT(cb != NULL);
                 int res = cb(data, tag, &(struct lfs_diskoff){
                         dir->pair[0], off+sizeof(tag)});
                 if (res < 0) {


### PR DESCRIPTION
  lfs_dir_fetch relies on an impossible tag match to avoid calling a
  NULL callback. Add an explicit cb != NULL check in the match path
  so future refactors don’t risk a NULL function-pointer call.