### PR TITLE
increase hint size in lfs_dir_traverse

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -930,7 +930,7 @@ static int lfs_dir_traverse(lfs_t *lfs,
             if (off+lfs_tag_dsize(ptag) < dir->off) {
                 off += lfs_tag_dsize(ptag);
                 int err = lfs_bd_read(lfs,
-                        NULL, &lfs->rcache, sizeof(tag),
+                        NULL, &lfs->rcache, lfs->cfg->block_size,
                         dir->pair[0], off, &tag, sizeof(tag));
                 if (err) {
                     return err;


### PR DESCRIPTION
Hi, I was noticing an issue where the number of read calls was too high. One of the functions that was causing this was lfs_dir_traverse. It was issuing read calls for each tag it read. From the comments in [pull request 621](https://github.com/littlefs-project/littlefs/pull/621), i concluded that the sequential reads could be reduced by increasing the hint size.

I compared the number of reads before and after changing the hint size and noticed a significant reduction (from 379K to 79K). The results are compiled in the attached excel file. These results were collected using the following script

```C
#include "lfs.h"
#include "lfs_rambd.h"
#include <stdio.h>

int readCount = 0;
int bytesRead = 0;

int read_with_count(const struct lfs_config *c, lfs_block_t block,
    lfs_off_t off, void *buffer, lfs_size_t size)
{
    readCount++;
    bytesRead += size;
    return lfs_rambd_read(c,block,off,buffer,size);
}

int main()
{
    struct lfs_rambd_config bdCfg = {
        .read_size = 1,
        .prog_size = 1,
        .erase_size = 256,
        .erase_count = 32768
    };
    lfs_rambd_t bd;
    
    lfs_t lfs;
    struct lfs_config lfsCfg = {
        .context =  &bd,
        .read = read_with_count,
        .prog = lfs_rambd_prog,
        .erase = lfs_rambd_erase,
        .sync = lfs_rambd_sync,
        .read_size = 1,
        .prog_size = 1,
        .block_size = 256,
        .block_count = 32768,
        .block_cycles = -1,
        .cache_size = 256,
        .lookahead_size = 4096
    };

    lfs_rambd_create(&lfsCfg,&bdCfg);
    lfs_format(&lfs, &lfsCfg);
    lfs_mount(&lfs, &lfsCfg);

    char fileData1[72];
    for (int i = 0; i < sizeof(fileData1); i++)
    {
        fileData1[i] = i;
    }

    lfs_mkdir(&lfs,"myDir");

    printf("iteration,bytesRead,readCount\n");
    int maxReadCount = 0;
    for (int i = 0; i < 120; i++)
    {
        lfs_file_t testFile;
        char fileName[100];
        sprintf(fileName,"myDir/test%d",i);
        lfs_file_open(&lfs,&testFile,fileName,LFS_O_RDWR|LFS_O_CREAT);
           
        for (int i = 0; i < 900; i++)
        {
            readCount = 0;
            bytesRead = 0;
            lfs_file_write(&lfs,&testFile,fileData1,sizeof(fileData1));
            
            if ((i%30)==0)
                lfs_file_sync(&lfs,&testFile);
            
            // if (readCount > maxReadCount){
            //     maxReadCount = readCount;
                printf("%d,%d,%d\n", i*900 + i, bytesRead, readCount);
            // }
        }
        
        lfs_file_close(&lfs,&testFile);
    }
    lfs_unmount(&lfs);    
}
```
[cache_dir_traverse.xlsx](https://github.com/user-attachments/files/24821767/cache_dir_traverse.xlsx)