### PR TITLE
Add basic CMake support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+# littlefs 
+
+add_library(littlefs INTERFACE)
+
+target_include_directories(littlefs INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}
+)
+
+target_sources(littlefs INTERFACE
+  lfs.c
+  lfs_util.c
+)
+
+if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+  target_compile_options(littlefs INTERFACE "-Wno-unused-function")
+endif()


### PR DESCRIPTION
Make it easy to add littlefs in CMake projects using _add_subdirectory()_ command.

To add littlefs in an existing CMake project, user can simply add one line in their CMakeLists.txt:
```
add_subdirectory(somepath/littlefs)
```
(where "somepath/littlefs" is path to the directory where littlefs source is found)