### PR TITLE
refactor: remove possibly unnecessary call to lfs_ctz_fromle32

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -1433,10 +1433,9 @@ static int lfs_dir_getinfo(lfs_t *lfs, lfs_mdir_t *dir,
     if (tag < 0) {
         return (int)tag;
     }
-    lfs_ctz_fromle32(&ctz);
 
     if (lfs_tag_type3(tag) == LFS_TYPE_CTZSTRUCT) {
-        info->size = ctz.size;
+        info->size = lfs_fromle32(ctz.size);
     } else if (lfs_tag_type3(tag) == LFS_TYPE_INLINESTRUCT) {
         info->size = lfs_tag_size(tag);
     }


### PR DESCRIPTION
 In `lfs_dir_getinfo` `lfs_ctz_fromle32` results not used if entry is `LFS_TYPE_INLINESTRUCT`.

In most cases, the compiler will optimize this anyway. But in debug builds, it makes sense.