### PR TITLE
Fix rcache data mismatch if lfs->cfg->read() returns an error (non-zero)

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -118,6 +118,7 @@ static int lfs_bd_read(lfs_t *lfs,
                 rcache->off, rcache->buffer, rcache->size);
         LFS_ASSERT(err <= 0);
         if (err) {
+            lfs_cache_drop(lfs, rcache);
             return err;
         }
     }


### PR DESCRIPTION

### Description
After a file is successfully opened and written, if the SD card fails (for example, the card is removed), subsequent operations may behave incorrectly.

A simplified example:

```C
file = lfs_open(); // Success

lfs_write(file, "something 1"); // Success

// Simulate SD card removal: lfs->cfg->read() now returns a negative error code

// During the next write, lfs attempts to write to the last block.
// The read operation fails, but rcache still points to the last block.
lfs_write(file, "something 2");   // Fails

// When reading the file and accessing the last block, rcache matches.
// Invalid data is read from rcache, and the return value is "LFS_ERR_OK".
error_code = lfs_read(file, buffer); // Returns "LFS_ERR_OK", but buffer contains invalid data
```
