### PR TITLE
Fix repeated words in comments

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -4804,7 +4804,7 @@ int lfs_fs_traverse_(lfs_t *lfs,
 #ifndef LFS_READONLY
 static int lfs_fs_pred(lfs_t *lfs,
         const lfs_block_t pair[2], lfs_mdir_t *pdir) {
-    // iterate over all directory directory entries
+    // iterate over all directory entries
     pdir->tail[0] = 0;
     pdir->tail[1] = 1;
     struct lfs_tortoise_t tortoise = {
@@ -5017,7 +5017,7 @@ static int lfs_fs_deorphan(lfs_t *lfs, bool powerloss) {
         lfs_mdir_t dir;
         bool moreorphans = false;
 
-        // iterate over all directory directory entries
+        // iterate over all directory entries
         while (!lfs_pair_isnull(pdir.tail)) {
             int err = lfs_dir_fetch(lfs, &dir, pdir.tail);
             if (err) {
@@ -5635,7 +5635,7 @@ static int lfs1_moved(lfs_t *lfs, const void *e) {
         return err;
     }
 
-    // iterate over all directory directory entries
+    // iterate over all directory entries
     lfs1_entry_t entry;
     while (!lfs_pair_isnull(cwd.d.tail)) {
         err = lfs1_dir_fetch(lfs, &cwd, cwd.d.tail);

--- a/scripts/plotmpl.py
+++ b/scripts/plotmpl.py
@@ -678,7 +678,7 @@ def main(csv_paths, output, *,
         plt.rc('patch', linewidth=0)
         plt.rc('axes', facecolor=foreground_, edgecolor=background_)
         plt.rc('grid', color=background_)
-        # fix the the gridlines when ggplot+xkcd
+        # fix the gridlines when ggplot+xkcd
         if xkcd:
             plt.rc('grid', linewidth=1)
             plt.rc('axes.spines', bottom=False, left=False)


### PR DESCRIPTION
Summary:
- Fix repeated words in three lfs.c comments about directory entry iteration.
- Fix a repeated word in the plotmpl.py ggplot+xkcd gridline comment.

Testing:
- git diff --check origin/master...HEAD

No runtime tests were run because this only changes comments.