### PR TITLE
Fix CTZ traverse pointer conversion count

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -3043,10 +3043,12 @@ static int lfs_ctz_traverse(lfs_t *lfs,
         err = lfs_bd_read(lfs,
                 pcache, rcache, count*sizeof(head),
                 head, 0, &heads, count*sizeof(head));
-        heads[0] = lfs_fromle32(heads[0]);
-        heads[1] = lfs_fromle32(heads[1]);
         if (err) {
             return err;
+        }
+
+        for (int i = 0; i < count; i++) {
+            heads[i] = lfs_fromle32(heads[i]);
         }
 
         for (int i = 0; i < count-1; i++) {


### PR DESCRIPTION
## Summary
- convert only the CTZ head pointers that `lfs_bd_read` actually filled
- move the conversion after the read error check, so failed reads do not decode local buffer contents
- avoid reading an uninitialized `heads[1]` slot when `count == 1`

Fixes #1214

## Testing
- `git diff --check`
- `git ls-files --eol lfs.c`
- Not run: `make test` requires the project test toolchain, but this Windows host does not have `make`, `cc`, or `gcc` available.