### PR TITLE
Assert that on-disk tags are never LFS_FROM_USERATTRS

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -937,6 +937,7 @@ static int lfs_dir_traverse(lfs_t *lfs,
                 }
 
                 tag = (lfs_frombe32(tag) ^ ptag) | 0x80000000;
+                LFS_ASSERT(lfs_tag_type3(tag) != LFS_FROM_USERATTRS);
                 disk.block = dir->pair[0];
                 disk.off = off+sizeof(lfs_tag_t);
                 buffer = &disk;


### PR DESCRIPTION
### Summary

Fixes #1135.

`LFS_FROM_USERATTRS` is an internal-only pseudo-type used by
`lfs_file_opencfg`/`lfs_dir_commit` to describe a source `struct lfs_attr*`
array to expand while committing attrs. It's never meant to be written to
disk as an actual tag type.

`lfs_dir_traverse`'s on-disk-tag branch decodes each stored tag and, for
`LFS_FROM_USERATTRS` tags specifically, reinterprets the tag's associated
data as that `struct lfs_attr*` array. If a corrupted or maliciously
crafted image contains a tag whose type happens to be
`LFS_FROM_USERATTRS`, the on-disk offset info (`lfs_diskoff`) gets
misread as a pointer, and traversal ends up dereferencing it as one.

This adds an assertion right after decoding the on-disk tag that rejects
this specific type before it reaches that branch — matching the
protection suggested in the issue, and consistent with how littlefs
already uses `LFS_ASSERT` elsewhere to guard invariants that should never
be violated by anything other than a corrupted/malicious filesystem
image.

### Testing

Verified with `tests/test_evil.toml`'s harness: committing a tag with
`LFS_MKTAG(LFS_FROM_USERATTRS, 0, size)` directly to an mdir (bypassing
the normal commit path, which only ever produces this pseudo-type
in-memory) and then mounting hits the new assertion cleanly — a
controlled abort with a clear message — instead of walking into the
reinterpreted offset.

I didn't include that as an automated test case: `test_runner` runs all
cases for a `.toml` file in a single process, so a case that's expected
to abort would take the rest of that run down with it rather than being
reported as one failure among many. Happy to add it in whatever form
you'd prefer if there's an existing convention for this I'm missing.

Ran the full test suite (`./runners/test_runner -Y`, all geometries)
before and after this change and got identical results (11766/12485
passing perms both times), confirming no unrelated regressions.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked
the code and is responsible for the code and the description above.