### PR TITLE
fix: propagate inline-ness into the tail-copy in lfs_file_flush

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -3367,9 +3367,12 @@ static int lfs_file_flush(lfs_t *lfs, lfs_file_t *file) {
             lfs_file_t orig = {
                 .ctz.head = file->ctz.head,
                 .ctz.size = file->ctz.size,
-                .flags = LFS_O_RDONLY,
+                .flags = LFS_O_RDONLY | (
+                    (file->ctz.head == LFS_BLOCK_INLINE) ? LFS_F_INLINE : 0),
                 .pos = file->pos,
                 .cache = lfs->rcache,
+                .m = file->m,
+                .id = file->id,
             };
             lfs_cache_drop(lfs, &lfs->rcache);
 


### PR DESCRIPTION
Fixes #1200.

## Root cause

`lfs_dir_orphaningcommit()` forcefully evicts (outlines) any open, too-large inline file before committing a directory. It does this by calling `lfs_file_outline()` followed directly by `lfs_file_flush()`, with no `lfs_file_write()` in between — this matters because it's a different path than the "normal" write-triggered outline.

`lfs_file_flush()`'s "copy over anything after current branch" logic builds a temporary `lfs_file_t` (`orig`) to read back the file's prior contents so they survive the transition to a real CTZ chain:

```c
lfs_file_t orig = {
    .ctz.head = file->ctz.head,
    .ctz.size = file->ctz.size,
    .flags = LFS_O_RDONLY,
    .pos = file->pos,
    .cache = lfs->rcache,
};
```

`lfs_file_outline()` only reassigns `file->block` (the new CTZ head under construction) and clears `LFS_F_INLINE` — it never touches `file->ctz.head`/`file->ctz.size`. So for a file that was inline right before this call, `orig.ctz.head` is still `LFS_BLOCK_INLINE` and `orig.ctz.size` is still the old inline size. But `orig.flags` has no `LFS_F_INLINE` bit, so `lfs_file_flushedread(lfs, &orig, ...)` takes the non-inline branch and passes `LFS_BLOCK_INLINE` to `lfs_bd_read()` as if it were a real block number, which fails and returns `LFS_ERR_CORRUPT` — matching the exact `lfs_bd_read` frame in the issue's own gdb backtrace.

`orig` also never had `.m` or `.id` set, both of which the inline read path (`lfs_dir_getread()`, keyed on `file->m`/`file->id`) needs to find the right metadata pair and file entry.

## Fix

Set `orig.flags`'s `LFS_F_INLINE` bit based on whether `orig.ctz.head` is still `LFS_BLOCK_INLINE`, and copy over `file->m`/`file->id`, so the read-back goes through the inline path when the prior data was inline — the same path `lfs_file_relocate()` itself already uses to read inline data a few lines earlier in the same file.

## Testing

Built the issue's own attached PoC (`main.c`) against this branch with plain `gcc` + the RAM block device (`bd/lfs_rambd.c`), no cross toolchain needed:

- `./poc 0` (sanity, never creates a large-inline situation) — passes on both master and this branch.
- `./poc 1` (open a large-inline file without seeking, then create another file in the same dir) — **fails with `error -84 line 97` on master**, **passes on this branch**.
- `./poc 2` (same as 1, but seeks to EOF first, which happens to sidestep the bug since the tail-copy loop's bound is then already satisfied) — passes on both.

I added temporary debug prints while tracking this down (`f->flags`/`pos`/`ctz.head`/`ctz.size` at the eviction check and again right after `lfs_file_outline()` returns) to confirm `ctz.head` really does stay `LFS_BLOCK_INLINE` (`0xFFFFFFFE`) straight through `lfs_file_outline()`, which is what led me to this fix rather than the eviction-condition itself (I initially suspected the `f->ctz.size > cache_size` check needed to be pos-aware, but confirmed that's not what's wrong here — that check already evaluates true either way for this repro, since the write happened in a prior mount session).

I wasn't able to run the full `scripts/test.py` suite in my environment (needs `termios`/`pty`, not available on my Windows host without a working WSL instance right now), so I can't provide a full regression-suite pass count for this PR the way I did for #1219. Happy to run it and report back if that's needed before this can be considered, or if a maintainer would rather I add a `tests/*.toml` case using this same repro shape.

## Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.