### PR TITLE
fix: initialize info->size for the root dir in lfs_dir_getinfo

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -1417,6 +1417,7 @@ static int lfs_dir_getinfo(lfs_t *lfs, lfs_mdir_t *dir,
         // special case for root
         strcpy(info->name, "/");
         info->type = LFS_TYPE_DIR;
+        info->size = 0;
         return 0;
     }
 


### PR DESCRIPTION
Fixes #1170.

`lfs_dir_getinfo()`'s special case for the root directory (`id == 0x3ff`) only sets `info->name` and `info->type`, leaving `info->size` untouched — so `stat("/")` returns whatever was already sitting in the caller's `struct lfs_info`, uninitialized if the caller didn't zero it first (confirmed real, not just theoretical — `littlefs-fuse` hits exactly this and shows garbage numbers in `ls -l` output, per the issue thread).

@geky noted in the issue that `littlefs3` already sets `info.size = 0` for this same case, and that doing the same in littlefs2 "may need to wait for a minor release" due to a small chance some downstream code depends on the current behavior. Opening this now so the fix is ready whenever the timing works — no urgency on my end, happy to have this sit until it fits a release, or to close/rework it if there's a preferred alternative (e.g. a `memset` at the top of `lfs_stat()` instead, as suggested by @rojer in the thread).

## Testing

Wrote a small standalone program against this branch (plain `gcc` + `bd/lfs_rambd.c`, no cross toolchain needed): format + mount a RAM-backed filesystem, `memset` a `struct lfs_info` to a `0xAA` sentinel pattern, then call `lfs_stat(&lfs, "/", &info)`.

- On `master`: `info.size` comes back as the untouched sentinel (`2863311530` / `0xAAAAAAAA`).
- On this branch: `info.size` comes back as `0`.

## Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.