### PR TITLE
fix: assert lfs->cfg is set in lfs_fs_gc before dereferencing it

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -6495,6 +6495,14 @@ int lfs_fs_mkconsistent(lfs_t *lfs) {
 
 #ifndef LFS_READONLY
 int lfs_fs_gc(lfs_t *lfs) {
+    // lfs->cfg is only assigned in lfs_init, which is only reachable via
+    // a successful lfs_mount/lfs_format. Calling lfs_fs_gc on an lfs_t
+    // that was never mounted (the common case for a statically/globally
+    // allocated lfs_t, which C zero-initializes) would otherwise deref a
+    // NULL cfg pointer below, trading a clear assertion failure for an
+    // unexplained crash.
+    LFS_ASSERT(lfs->cfg != NULL);
+
     int err = LFS_LOCK(lfs->cfg);
     if (err) {
         return err;


### PR DESCRIPTION
Fixes #1201.

## Problem

`lfs_fs_gc()` unconditionally dereferences `lfs->cfg`:

https://github.com/littlefs-project/littlefs/blob/6cb4e86540eca0d9ba62500a298385c9d863c8be/lfs.c#L5211-L5213

```c
if (lfs->cfg->compact_thresh
        < lfs->cfg->block_size - lfs->cfg->prog_size) {
```

(and, when `LFS_THREADSAFE` is defined, even earlier via `LFS_LOCK(lfs->cfg)` -> `lfs->cfg->lock(cfg)` at the top of `lfs_fs_gc`).

`lfs->cfg` is only ever assigned in `lfs_init()`:

```c
static int lfs_init(lfs_t *lfs, const struct lfs_config *cfg) {
    lfs->cfg = cfg;
    ...
```

and `lfs_init()` is only reachable through a successful `lfs_mount()` / `lfs_format()` (I grepped the whole file — those are the only two call sites).

So if `lfs_fs_gc()` is called on an `lfs_t` that was never mounted, `lfs->cfg` is still whatever it was before — for the common pattern of a statically or globally allocated `lfs_t` (which C zero-initializes), that's `NULL`. The result is an unexplained null-pointer dereference/segfault instead of a diagnosable error, as reported in #1201.

## Fix

Add a single `LFS_ASSERT(lfs->cfg != NULL)` at the very top of `lfs_fs_gc()`, before `LFS_LOCK`, so both `LFS_THREADSAFE` and non-threadsafe builds hit the same clear assertion instead of a raw crash. This mirrors the ~28 other `LFS_ASSERT`s already used in `lfs_init()`/elsewhere in `lfs.c` to catch programmer errors (e.g. validating `cfg->read`/`prog`/`erase`/`sync`) rather than let them turn into undefined behavior.

Diff is a single 8-line addition to `lfs.c` (comment + one assert), no other changes.

### Scope note

Nearly all public API entry points in `lfs.c` (`lfs_stat`, `lfs_open`, `lfs_remove`, `lfs_rename`, ~25 functions total) share the same "first thing is `LFS_LOCK(lfs->cfg)`" pattern, so in principle calling *any* of them before mounting has the same failure mode — that's an implicit "must mount first" contract for the whole library, not something specific to `lfs_fs_gc`. Issue #1201 only asked about `lfs_fs_gc`, and adding the same assert to all ~25 entry points is a bigger, library-wide design decision that deserves a maintainer call rather than being bundled into this fix. This PR intentionally stays scoped to the one function reported in the issue.

## Verification

Compiled `lfs.c` standalone with `gcc -std=c99 -Wall -Wextra -c -I. lfs.c` after the change — no new warnings.

I also wrote an independent repro against the real, unmodified `lfs.c`/`lfs.h`/`lfs_util.c` from this repo (only a minimal `lfs_config` stub, no rewritten logic): a statically-declared `lfs_t` (zero-initialized, never mounted) calling `lfs_fs_gc(&lfs)` directly.

- **Before the patch:** `Segmentation fault` (exit code 139 / SIGSEGV) — matches the "nllptr deref" in the issue.
- **After the patch:** clean, actionable failure instead of a crash:
  ```
  Assertion failed!
  File: lfs_after.c, Line 6503
  Expression: lfs->cfg != ((void *)0)
  ```
  (exit code 3 / SIGABRT via the assert path)
- Also rebuilt the "before" repro with `-DLFS_THREADSAFE` and confirmed it still crashes, just at the earlier `cfg->lock(cfg)` site — confirming the new assert placement (before `LFS_LOCK`) catches the misuse at the earliest point under both configurations.

Checked `tests/test_alloc.toml`: every existing call to `lfs_fs_gc(&lfs)` happens after a successful `lfs_mount`/`lfs_format`, so this assert shouldn't trip any current test.

(I don't have `make`/the full test toolchain set up in this environment, so I wasn't able to run the complete `scripts/test.py` suite — happy to iterate if CI turns up something.)

## Disclosure

I used Claude (Anthropic) to help investigate this issue (tracing the `lfs->cfg` assignment/call graph, writing and running the before/after repro programs) and to draft this fix and PR description. I've reviewed the diff, the root-cause analysis, and the repro output myself before submitting. Happy to answer questions or make changes if the approach isn't what maintainers want.
